### PR TITLE
Accept lower-case 'y' responses to confirmation prompt

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -75,7 +75,7 @@ func Confirm(defaultYes bool, prompt string) bool {
 
 	answer := Ask(prompt + extra)
 
-	if answer == "Y" || (defaultYes && answer == "") {
+	if strings.ToUpper(answer) == "Y" || (defaultYes && answer == "") {
 		return true
 	}
 


### PR DESCRIPTION
*Description of changes:*
This change allows either "y" or "Y" to be acceptable as a "yes" response
for confirmation prompts, whereas the previous behaviour was to only
accept "Y".

For example, when performing a `rain deploy`, the current behaviour is:
```
Do you wish to continue? (Y/n) y
User cancelled deployment.
< rain exits >
```

With this change:
```
Do you wish to continue? (Y/n) y
< deployment proceeds >
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
