### PR TITLE
Hide nested stacks by default in `ls` output. Add a flag to show them…

### DIFF
--- a/cmd/ls_test.go
+++ b/cmd/ls_test.go
@@ -24,8 +24,9 @@ func Example_ls_help() {
 	//   ls, list
 	//
 	// Flags:
-	//   -a, --all    List stacks across all regions
-	//   -h, --help   help for ls
+	//   -a, --all      List stacks across all regions
+	//   -h, --help     help for ls
+	//   -n, --nested   Show nested stacks (hidden by default)
 	//
 	// Global Flags:
 	//       --debug            Output debugging information

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -19,6 +19,10 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
 )
 
+func indent(prefix string, in string) string {
+	return prefix + strings.Join(strings.Split(strings.TrimSpace(in), "\n"), "\n"+prefix)
+}
+
 func colouriseStatus(status string) text.Text {
 	switch {
 	case strings.HasSuffix(status, "_FAILED"):

--- a/cmd/util_test.go
+++ b/cmd/util_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/aws-cloudformation/rain/cfn/diff"
 	"github.com/aws-cloudformation/rain/console"
 	"github.com/aws-cloudformation/rain/console/text"
@@ -95,5 +97,24 @@ func TestStatusIsSettled(t *testing.T) {
 		if statusIsSettled(input) != expected {
 			t.Fail()
 		}
+	}
+}
+
+func TestIndent(t *testing.T) {
+	input := `This
+has
+multiple
+lines
+`
+
+	expected := `  This
+  has
+  multiple
+  lines` // Should chomp ending blank lines
+
+	actual := indent("  ", input)
+
+	if d := cmp.Diff(actual, expected); d != "" {
+		t.Errorf(d)
 	}
 }


### PR DESCRIPTION
… indented.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
