### PR TITLE
Fix for bare timestamps in yaml being converted to dates

### DIFF
--- a/cfn/parse/parse_test.go
+++ b/cfn/parse/parse_test.go
@@ -51,6 +51,22 @@ var expected = cfn.Template(map[string]interface{}{
 				},
 			},
 		},
+		"ExecutionRole": map[string]interface{}{
+			"Properties": map[string]interface{}{
+				"AssumeRolePolicyDocument": map[string]interface{}{
+					"Statement": []interface{}{
+						map[string]interface{}{
+							"Action":    "sts:AssumeRole",
+							"Effect":    "Allow",
+							"Principal": map[string]interface{}{"Service": "lambda.amazonaws.com"},
+						},
+					},
+					"Version": "2012-10-17",
+				},
+				"Path": "/",
+			},
+			"Type": "AWS::IAM::Role",
+		},
 	},
 	"Outputs": map[string]interface{}{
 		"Bucket1Arn": map[string]interface{}{
@@ -75,6 +91,7 @@ var expected = cfn.Template(map[string]interface{}{
 			},
 		},
 	},
+	"AWSTemplateFormatVersion": "2010-09-09",
 })
 
 func init() {

--- a/cfn/parse/test.yaml
+++ b/cfn/parse/test.yaml
@@ -25,6 +25,18 @@ Resources:
       BucketName: !Base64
         Ref: Cakes
 
+  ExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Path: /
+
 Outputs:
   Bucket1Arn:
     Value: !GetAtt Bucket1.Arn
@@ -35,3 +47,4 @@ Outputs:
       Fn::GetAtt:
         - Bucket2
         - Arn
+AWSTemplateFormatVersion: 2010-09-09

--- a/cfn/parse/transform.go
+++ b/cfn/parse/transform.go
@@ -32,6 +32,11 @@ func transform(node *yaml.Node) {
 		node.Tag = "!!str"
 	}
 
+	// Fix badly-parsed timestamps which are often used for versions in cloudformation
+	if node.ShortTag() == "!!timestamp" {
+		node.Tag = "!!str"
+	}
+
 	// See if we're dealing with a Fn:: tag
 	for _, tag := range tags {
 		if node.ShortTag() == "!"+tag {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When parsing templates with timestamp versions `rain` would fail.

This at the top of a template would break it.

```
"AWSTemplateFormatVersion": 2010-09-09
```

So to mitigate this I am using the transform to ensure all timestamps are converted to strings.

I have added testes to illustrate the problem, these fail without the change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
