### PR TITLE
Explicitly close temp template file before deleting it

### DIFF
--- a/internal/cmd/deploy/util.go
+++ b/internal/cmd/deploy/util.go
@@ -165,6 +165,7 @@ func packageTemplate(fn string) cft.Template {
 	}
 	defer func() {
 		config.Debugf("Removing temporary template file: %s", outputFn.Name())
+		outputFn.Close()
 		err := os.Remove(outputFn.Name())
 		if err != nil {
 			panic(ui.Errorf(err, "error removing temporary template file '%s'", outputFn.Name()))


### PR DESCRIPTION
*Issue #52, if available:* 

* fix #52

*Description of changes:*

Added explicitly file closing for deleting correctly on Windows environment.


