### PR TITLE
Corrects the default stack name of rain deploy on Windows

### DIFF
--- a/internal/cmd/deploy/deploy.go
+++ b/internal/cmd/deploy/deploy.go
@@ -3,7 +3,6 @@ package deploy
 import (
 	"errors"
 	"fmt"
-	"path"
 	"path/filepath"
 	"regexp"
 
@@ -39,14 +38,14 @@ The bucket's name will be of the format rain-artifacts-<AWS account id>-<AWS reg
 	DisableFlagsInUseLine: true,
 	Run: func(cmd *cobra.Command, args []string) {
 		fn := args[0]
-		base := path.Base(fn)
+		base := filepath.Base(fn)
 
 		var stackName string
 
 		if len(args) == 2 {
 			stackName = args[1]
 		} else {
-			stackName = base[:len(base)-len(path.Ext(base))]
+			stackName = base[:len(base)-len(filepath.Ext(base))]
 
 			// Now ensure it's a valid cfc name
 			stackName = fixStackNameRe.ReplaceAllString(stackName, "-")


### PR DESCRIPTION
*Issue #, if available:*

No Issue #, related #52 .

*Description of changes:*

In current latest master branch, `rain deploy` treats incorrectly default stack name on Windows. 
[path](https://golang.org/pkg/path/) Package doesn't treat backslash as a separator, so if <template> parameter is specified as absolute path, default stack name is as follows.

```powershell
# 
# Current behavior : C-temp-sample is stack name of C:\temp\sample.yaml tempalte 
# 
PS > $env:AWS_PROFILE="my_profile"
PS > .\rain.exe deploy C:\temp\sample.yaml
Preparing template 'C:\temp\sample.yaml' ˙ ·
Loading AWS config ˙ ·

# snip ...

Checking current status of stack 'C-temp-sample' .·

# snip ...

Creating change set  .˙

# snip ...

CloudFormation will make the following changes:
Stack C-temp-sample:
  + AWS::S3::Bucket MyBucket
Do you wish to continue? (Y/n) 
```

This pull request improves this behavior as expected.

```powershell
# 
# Improved behavior : sample is stack name of C:\temp\sample.yaml tempalte 
# 
PS > $env:AWS_PROFILE="my_profile"
PS > .\rain.exe deploy C:\temp\sample.yaml
Preparing template 'sample.yaml' ˙ ·
Loading AWS config ˙ ·

# snip ...

Checking current status of stack 'sample' ˙ ·

# snip ...

Creating change set .·

# snip ...

CloudFormation will make the following changes:
Stack sample:
  + AWS::S3::Bucket MyBucket
Do you wish to continue? (Y/n)
```

