### PR TITLE
Improve terminal detection logic.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/aws-cloudformation/rain
 go 1.15
 
 require (
-	github.com/andrew-d/go-termutil v0.0.0-20150726205930-009166a695a2
 	github.com/aws/aws-sdk-go-v2 v1.2.0
 	github.com/aws/aws-sdk-go-v2/config v1.1.1
 	github.com/aws/aws-sdk-go-v2/credentials v1.1.1
@@ -20,5 +19,7 @@ require (
 	github.com/nathan-fiscaletti/consolesize-go v0.0.0-20210105204122-a87d9f614b9d
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
+	golang.org/x/sys v0.0.0-20201119102817-f84b799fce68
+	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,6 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/andrew-d/go-termutil v0.0.0-20150726205930-009166a695a2 h1:axBiC50cNZOs7ygH5BgQp4N+aYrZ2DNpWZ1KG3VOSOM=
-github.com/andrew-d/go-termutil v0.0.0-20150726205930-009166a695a2/go.mod h1:jnzFpU88PccN/tPPhCpnNU8mZphvKxYM9lLNkd8e+os=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
@@ -332,7 +330,12 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0 h1:HyfiK1WMnHj5FXFXatD+Qs1A/xC2Run6RzeW1SyHxpc=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d h1:SZxvLBoTP5yHO3Frd4z4vrF+DBX9vMVanchswa69toE=
+golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/internal/console/console.go
+++ b/internal/console/console.go
@@ -6,26 +6,26 @@ import (
 	"fmt"
 	"math"
 	"os"
-	"runtime"
 	"strings"
 
-	"github.com/andrew-d/go-termutil"
 	"github.com/chzyer/readline"
 	"github.com/gookit/color"
 	"github.com/nathan-fiscaletti/consolesize-go"
+	"golang.org/x/term"
 )
 
 // IsTTY will be true if stdout is connected to a true terminal
 var IsTTY bool
 
+// isANSI will be true if console supports ANSI escape code. It is for Windows only.
+var isANSI bool
+
 // NoColour should be false if you want output to be coloured
 var NoColour = false
 
-var isANSI bool
-
 func init() {
-	IsTTY = termutil.Isatty(os.Stdout.Fd())
-	isANSI = runtime.GOOS != "windows"
+	IsTTY = term.IsTerminal(int(os.Stdout.Fd()))
+	isANSI = true
 }
 
 // Size returns the width and height of the console in characters

--- a/internal/console/console_windows.go
+++ b/internal/console/console_windows.go
@@ -1,0 +1,30 @@
+// +build windows
+
+// Package console contains utility functions for working with text consoles
+package console
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+	"golang.org/x/term"
+)
+
+func init() {
+	var fd = os.Stdout.Fd()
+	IsTTY = term.IsTerminal(int(fd))
+	isANSI = isANSISupport(fd)
+}
+
+func isANSISupport(fd uintptr) bool {
+	var consoleHandle = windows.Handle(fd)
+	var consoleMode uint32
+	err := windows.GetConsoleMode(consoleHandle, &consoleMode)
+	if err != nil {
+		return false
+	}
+	if (consoleMode & windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING) != windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING {
+		return false
+	}
+	return true
+}


### PR DESCRIPTION

*Issue #, if available:*

* No Issue # 

*Description of changes:*

This pull request mainly improves terminal detection on Windows.  

Since Windows 10 ver.1607, ANSI escape code supported on Windows and `ENABLE_VIRTUAL_TERMINAL_PROCESSING` flag is used for detecting and enabling this feature.

* See : [Console Virtual Terminal Sequences](https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences?redirectedfrom=MSDN)

In addition, I have modified it to use the [term](https://pkg.go.dev/golang.org/x/term) package for unified processing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
