### PR TITLE
Support for list paramaters in `rain deploy`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,9 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.2.0
 	github.com/aws/aws-sdk-go-v2/service/sts v1.1.1
 	github.com/aws/smithy-go v1.1.0
+	github.com/chzyer/logex v1.1.10 // indirect
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
+	github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 // indirect
 	github.com/google/go-cmp v0.5.4
 	github.com/google/uuid v1.2.0
 	github.com/gookit/color v1.3.8
@@ -19,6 +21,7 @@ require (
 	github.com/nathan-fiscaletti/consolesize-go v0.0.0-20210105204122-a87d9f614b9d
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
+	github.com/stretchr/testify v1.3.0
 	golang.org/x/sys v0.0.0-20201119102817-f84b799fce68
 	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,10 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
+github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
+github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/internal/cmd/deploy/deploy.go
+++ b/internal/cmd/deploy/deploy.go
@@ -59,7 +59,11 @@ The bucket's name will be of the format rain-artifacts-<AWS account id>-<AWS reg
 		parsedTags := listToMap("tag", tags)
 
 		// Parse params
-		parsedParams := listToMap("param", params)
+		repairedParams, err := repairValuesWithCommas(params)
+		if err != nil {
+			panic(ui.Errorf(err, "Error parsing the params"))
+		}
+		parsedParams := listToMap("param", repairedParams)
 
 		// Package template
 		spinner.Push(fmt.Sprintf("Preparing template '%s'", base))

--- a/internal/cmd/deploy/util.go
+++ b/internal/cmd/deploy/util.go
@@ -242,13 +242,16 @@ func checkStack(stackName string) (types.Stack, bool) {
 	return stack, stackExists
 }
 
-//repairValuesWithCommas takes KeyValues which
-//must be a slice "key=value" style with
-//possibly broken (caused by using SliceVarP from Cobra)
-//entries such as
-//  []string{"key=value1" "value2" "key2=anothervalue"}
-//Will return the slice
-//  []string{"key=value1,value2" "key2=anothervalue"}
+// repairValuesWithCommas takes a []string{}
+// with entries on the fromat of "key=value" and fixes
+// possibly broken (caused by using SliceVarP from Cobra)
+// entries on the comma sign.
+//
+// Entries such as
+//   []string{"key=value1" "value2" "key2=anothervalue"}
+// Will return the slice
+//   []string{"key=value1,value2" "key2=anothervalue"}
+// Se tests for up2date usage and description ;)
 func repairValuesWithCommas(keyValues []string) ([]string, error) {
 
 	if len(keyValues) > 0 && !strings.ContainsAny(keyValues[0], "=") {

--- a/internal/cmd/deploy/util.go
+++ b/internal/cmd/deploy/util.go
@@ -250,10 +250,8 @@ func checkStack(stackName string) (types.Stack, bool) {
 //Will return the slice
 //  []string{"key=value1,value2" "key2=anothervalue"}
 func repairValuesWithCommas(keyValues []string) ([]string, error) {
-	if len(keyValues) < 1 {
-		return []string{}, nil
-	}
-	if !strings.ContainsAny(keyValues[0], "=") {
+
+	if len(keyValues) > 0 && !strings.ContainsAny(keyValues[0], "=") {
 		return []string{}, errors.New("not on the correct key=value format")
 	}
 

--- a/internal/cmd/deploy/util_test.go
+++ b/internal/cmd/deploy/util_test.go
@@ -1,0 +1,46 @@
+package deploy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListToMapOneString(t *testing.T) {
+	parameterList := []string{"aoeu=htns"}
+	expectedParameterMap := map[string]string{
+		"aoeu": "htns",
+	}
+
+	assert.Equal(t,
+		expectedParameterMap,
+		listToMap("", parameterList),
+	)
+}
+
+func TestListToMapCommaValue(t *testing.T) {
+	parameterList := []string{"aoeu=htns,thing"}
+	expectedParameterMap := map[string]string{
+		"aoeu": "htns,thing",
+	}
+
+	assert.Equal(t,
+		expectedParameterMap,
+		listToMap("", parameterList),
+	)
+}
+
+func TestListToMapMultipleEntriesValue(t *testing.T) {
+	parameterList := []string{"aoeu=htns", "key2=value2", "key3=YetAnotherValue"}
+	expectedParameterMap := map[string]string{
+		"aoeu": "htns",
+		"key2": "value2",
+		"key3": "YetAnotherValue",
+	}
+
+	assert.Equal(t,
+		expectedParameterMap,
+		listToMap("", parameterList),
+	)
+}
+

--- a/internal/cmd/deploy/util_test.go
+++ b/internal/cmd/deploy/util_test.go
@@ -44,3 +44,36 @@ func TestListToMapMultipleEntriesValue(t *testing.T) {
 	)
 }
 
+func TestRepairValuesWithCommasOneBrokenParameter(t *testing.T) {
+	brokenCommaValue := []string{"key=value1", "value2"}
+	expectedRepairedValue := []string{"key=value1,value2"}
+
+	repairedValue, _ := repairValuesWithCommas(brokenCommaValue)
+	assert.Equal(t,
+		expectedRepairedValue,
+		repairedValue,
+	)
+}
+
+func TestRepairValuesWithCommasOneBrokenParameterAndOneCorrect(t *testing.T) {
+	brokenCommaValue := []string{"key=value1", "value2", "key2=anotherValue"}
+	expectedRepairedValue := []string{"key=value1,value2", "key2=anotherValue"}
+
+	repairedValue, _ := repairValuesWithCommas(brokenCommaValue)
+	assert.Equal(t,
+		expectedRepairedValue,
+		repairedValue,
+	)
+}
+
+func TestRepairValuesWithCommasPanicOnNoKeyStart(t *testing.T) {
+	faultyValues := []string{"NoKeyedValue"}
+
+	_, err := repairValuesWithCommas(faultyValues)
+	assert.NotNil(t, err)
+}
+
+func TestRepairValuesWithCommasReturnsEmptyOnEmptyInput(t *testing.T) {
+	repairedValuesEmpty, _ := repairValuesWithCommas([]string{})
+	assert.Equal(t, repairedValuesEmpty, []string{})
+}


### PR DESCRIPTION
Right now `rain deploy --params` do not support lists types i.e. `rain deploy --params PublicSubnet=Net-1,Net-2` since cobra `FlagSets.SliceVarP` use comma as a delimiter when it splits up the string.

I added a function that repairs such, for our use case, broken divisions before we convert the parameter slice to a map. 

Thus with this change we can pass in List types! 

Also added a few tests for the internal functions of listToMap and repairValuesWithCommas i used during development. Perhaps they should be refactored so we test Cmd instead. But they do act as good documentation on how those functions work. 