### PR TITLE
Add --role-arn option for deploy sub command.

### DIFF
--- a/internal/aws/cfn/cfn.go
+++ b/internal/aws/cfn/cfn.go
@@ -161,7 +161,7 @@ func GetStackEvents(stackName string) ([]types.StackEvent, error) {
 }
 
 // CreateChangeSet creates a changeset
-func CreateChangeSet(template cft.Template, params []types.Parameter, tags map[string]string, stackName string) (string, error) {
+func CreateChangeSet(template cft.Template, params []types.Parameter, tags map[string]string, stackName string, roleArn string) (string, error) {
 	templateBody, err := checkTemplate(template)
 	if err != nil {
 		return "", err
@@ -190,6 +190,10 @@ func CreateChangeSet(template cft.Template, params []types.Parameter, tags map[s
 			"CAPABILITY_NAMED_IAM",
 			"CAPABILITY_AUTO_EXPAND",
 		},
+	}
+
+	if roleArn != "" {
+		input.RoleARN = &roleArn
 	}
 
 	if strings.HasPrefix(templateBody, "http://") {

--- a/internal/aws/cfn/cfn.go
+++ b/internal/aws/cfn/cfn.go
@@ -193,7 +193,7 @@ func CreateChangeSet(template cft.Template, params []types.Parameter, tags map[s
 	}
 
 	if roleArn != "" {
-		input.RoleARN = &roleArn
+		input.RoleARN = ptr.String(roleArn)
 	}
 
 	if strings.HasPrefix(templateBody, "http://") {

--- a/internal/aws/cfn/mock.go
+++ b/internal/aws/cfn/mock.go
@@ -29,6 +29,7 @@ type mockChangeSet struct {
 	params    []types.Parameter
 	tags      map[string]string
 	stackName string
+	roleArn string
 }
 
 type regionConfig struct {
@@ -159,7 +160,7 @@ func GetStackEvents(stackName string) ([]types.StackEvent, error) {
 }
 
 // CreateChangeSet creates a changeset
-func CreateChangeSet(template cft.Template, params []types.Parameter, tags map[string]string, stackName string) (string, error) {
+func CreateChangeSet(template cft.Template, params []types.Parameter, tags map[string]string, stackName string, roleArn string) (string, error) {
 	name := uuid.New().String()
 
 	region().changeSets[name] = &mockChangeSet{
@@ -167,6 +168,7 @@ func CreateChangeSet(template cft.Template, params []types.Parameter, tags map[s
 		params:    params,
 		tags:      tags,
 		stackName: stackName,
+		roleArn: roleArn,
 	}
 
 	return name, nil

--- a/internal/cmd/deploy/deploy.go
+++ b/internal/cmd/deploy/deploy.go
@@ -23,6 +23,7 @@ var params []string
 var tags []string
 var terminationProtection bool
 var keep bool
+var roleArn string
 
 // Cmd is the deploy command's entrypoint
 var Cmd = &cobra.Command{
@@ -87,7 +88,7 @@ The bucket's name will be of the format rain-artifacts-<AWS account id>-<AWS reg
 
 		// Create change set
 		spinner.Push("Creating change set")
-		changeSetName, createErr := cfn.CreateChangeSet(template, parameters, parsedTags, stackName)
+		changeSetName, createErr := cfn.CreateChangeSet(template, parameters, parsedTags, stackName, roleArn)
 		if createErr != nil {
 			panic(ui.Errorf(createErr, "error creating changeset"))
 		}
@@ -173,4 +174,5 @@ func init() {
 	Cmd.Flags().StringSliceVar(&params, "params", []string{}, "Set parameter values. Use the format key1=value1,key2=value2.")
 	Cmd.Flags().BoolVarP(&terminationProtection, "termination-protection", "t", false, "Enable  termination protection on the stack.")
 	Cmd.Flags().BoolVarP(&keep, "keep", "k", false, "Keep deployed resources after a failure by disabling rollbacks.")
+	Cmd.Flags().StringVarP(&roleArn, "role-arn", "", "", "The ARN of IAM role that AWS CloudFormation assumes to deploy the stack.")
 }

--- a/internal/cmd/deploy/deploy_test.go
+++ b/internal/cmd/deploy/deploy_test.go
@@ -29,6 +29,7 @@ func Example_deploy_help() {
 	//   -h, --help                     help for deploy
 	//   -k, --keep                     Keep deployed resources after a failure by disabling rollbacks.
 	//       --params strings           Set parameter values. Use the format key1=value1,key2=value2.
+	//       --role-arn string          The ARN of IAM role that AWS CloudFormation assumes to deploy the stack.
 	//       --tags strings             Add tags to the stack. Use the format key1=value1,key2=value2.
 	//   -t, --termination-protection   Enable  termination protection on the stack.
 	//   -y, --yes                      Don't ask questions; just deploy.


### PR DESCRIPTION
*Issue #, if available:* #71

*Description of changes:* Add `--role-arn` option for deploy sub command to set service role.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
