### PR TITLE
fix: exit with a success code instead of a panic when change set includes no change.

### DIFF
--- a/internal/aws/cfn/cfn.go
+++ b/internal/aws/cfn/cfn.go
@@ -21,10 +21,6 @@ import (
 	"github.com/aws/smithy-go/ptr"
 )
 
-const noChangeFoundMsg = "The submitted information didn't contain changes. Submit different information to create a change set."
-
-var ErrNoChange = errors.New(noChangeFoundMsg)
-
 var liveStatuses = []types.StackStatus{
 	"CREATE_IN_PROGRESS",
 	"CREATE_FAILED",
@@ -265,11 +261,7 @@ func CreateChangeSet(template cft.Template, params []types.Parameter, tags map[s
 		config.Debugf("ChangeSet status: %s", status)
 
 		if status == "FAILED" {
-			if ptr.ToString(res.StatusReason) == noChangeFoundMsg {
-				return changeSetName, ErrNoChange
-			} else {
-				return changeSetName, errors.New(ptr.ToString(res.StatusReason))
-			}
+			return changeSetName, errors.New(ptr.ToString(res.StatusReason))
 		}
 
 		if strings.HasSuffix(status, "_COMPLETE") {

--- a/internal/cmd/deploy/deploy.go
+++ b/internal/cmd/deploy/deploy.go
@@ -162,7 +162,8 @@ YAML:
 		changeSetName, createErr := cfn.CreateChangeSet(template, parameters, combinedTags, stackName, roleArn)
 		if createErr != nil {
 			if createErr.Error() == noChangeFoundMsg {
-				fmt.Println(console.Green("\nChange set was created, but there is no change. Deploy was skipped."))
+				spinner.Pop()
+				fmt.Println(console.Green("Change set was created, but there is no change. Deploy was skipped."))
 				return
 			} else {
 				panic(ui.Errorf(createErr, "error creating changeset"))

--- a/internal/cmd/deploy/deploy.go
+++ b/internal/cmd/deploy/deploy.go
@@ -19,6 +19,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const noChangeFoundMsg = "The submitted information didn't contain changes. Submit different information to create a change set."
+
 type configFileFormat struct {
 	Parameters map[string]string `yaml:"Parameters"`
 	Tags       map[string]string `yaml:"Tags"`
@@ -159,12 +161,11 @@ YAML:
 		spinner.Push("Creating change set")
 		changeSetName, createErr := cfn.CreateChangeSet(template, parameters, combinedTags, stackName, roleArn)
 		if createErr != nil {
-			switch createErr {
-				case cfn.ErrNoChange:
-					fmt.Println(console.Green("\nChange set was created, but there is no change. Deploy was skipped."))
-					return
-				default:
-					panic(ui.Errorf(createErr, "error creating changeset"))
+			if createErr.Error() == noChangeFoundMsg {
+				fmt.Println(console.Green("\nChange set was created, but there is no change. Deploy was skipped."))
+				return
+			} else {
+				panic(ui.Errorf(createErr, "error creating changeset"))
 			}
 		}
 

--- a/internal/cmd/deploy/deploy.go
+++ b/internal/cmd/deploy/deploy.go
@@ -159,7 +159,13 @@ YAML:
 		spinner.Push("Creating change set")
 		changeSetName, createErr := cfn.CreateChangeSet(template, parameters, combinedTags, stackName, roleArn)
 		if createErr != nil {
-			panic(ui.Errorf(createErr, "error creating changeset"))
+			switch createErr {
+				case cfn.ErrNoChange:
+					fmt.Println(console.Green("\nChange set was created, but there is no change. Deploy was skipped."))
+					return
+				default:
+					panic(ui.Errorf(createErr, "error creating changeset"))
+			}
 		}
 
 		changeSetStatus, err := cfn.GetChangeSet(stackName, changeSetName)


### PR DESCRIPTION
*Issue #, if available:* #73

*Description of changes:* When change set includes no change, rain exits with a success code instead of a panic.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
