### PR TITLE
Fix return an error of index out of range without panic

### DIFF
--- a/cft/parse/parse.go
+++ b/cft/parse/parse.go
@@ -57,8 +57,8 @@ func String(input string) (cft.Template, error) {
 
 // Node returns a cft.Template parse from a *yaml.Node
 func Node(node *yaml.Node) (cft.Template, error) {
-	TransformNode(node)
-	return cft.Template{Node: node}, nil
+	err := TransformNode(node)
+	return cft.Template{Node: node}, err
 }
 
 // Verify confirms that there is no semantic difference between


### PR DESCRIPTION
*Issue #, if available:*
An incorrect `!GetAtt` reference only for _logicalName_ (e.g. `!GetAtt Resource1`) caused an out-of-array reference
```
$ ./rain fmt test.yaml --debug
panic: runtime error: index out of range [1] with length 1 [recovered]
	panic: runtime error: index out of range [1] with length 1

goroutine 1 [running]:
github.com/aws-cloudformation/rain/internal/cmd.execute.func1(0xc000587f58)
	github.com/aws-cloudformation/rain/internal/cmd/wrap.go:77 +0x225
panic(0x1943d00, 0xc0000c0450)
	runtime/panic.go:965 +0x1b9
github.com/aws-cloudformation/rain/cft/parse.parseGetAtt(0xc000610be0)
	github.com/aws-cloudformation/rain/cft/parse/transform.go:33 +0x2cf
github.com/aws-cloudformation/rain/cft/parse.TransformNode(0xc000610b40)
	github.com/aws-cloudformation/rain/cft/parse/transform.go:86 +0x42f
github.com/aws-cloudformation/rain/cft/parse.TransformNode(0xc000610780)
	github.com/aws-cloudformation/rain/cft/parse/transform.go:91 +0x3fe
github.com/aws-cloudformation/rain/cft/parse.TransformNode(0xc000610500)
	github.com/aws-cloudformation/rain/cft/parse/transform.go:91 +0x3fe
github.com/aws-cloudformation/rain/cft/parse.TransformNode(0xc00059d900)
	github.com/aws-cloudformation/rain/cft/parse/transform.go:91 +0x3fe
github.com/aws-cloudformation/rain/cft/parse.TransformNode(0xc00059d680)
	github.com/aws-cloudformation/rain/cft/parse/transform.go:91 +0x3fe
github.com/aws-cloudformation/rain/cft/parse.TransformNode(0xc00059d540)
	github.com/aws-cloudformation/rain/cft/parse/transform.go:91 +0x3fe
github.com/aws-cloudformation/rain/cft/parse.Node(...)
	github.com/aws-cloudformation/rain/cft/parse/parse.go:60
github.com/aws-cloudformation/rain/cft/parse.String(0xc00010a000, 0x121, 0x121, 0xc00010a000, 0x121)
	github.com/aws-cloudformation/rain/cft/parse/parse.go:55 +0x136
github.com/aws-cloudformation/rain/internal/cmd/fmt.formatReader(0x7ff7bfeffa89, 0x9, 0x1fbda60, 0xc0000c61a0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	github.com/aws-cloudformation/rain/internal/cmd/fmt/fmt.go:43 +0x116
github.com/aws-cloudformation/rain/internal/cmd/fmt.formatFile(0x7ff7bfeffa89, 0x9, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	github.com/aws-cloudformation/rain/internal/cmd/fmt/fmt.go:75 +0x1d5
github.com/aws-cloudformation/rain/internal/cmd/fmt.glob..func1(0x2301de0, 0xc0000d4d80, 0x1, 0x2)
	github.com/aws-cloudformation/rain/internal/cmd/fmt/fmt.go:108 +0xb2
github.com/spf13/cobra.(*Command).execute(0x2301de0, 0xc0000d44a0, 0x2, 0x2, 0x2301de0, 0xc0000d44a0)
	github.com/spf13/cobra@v1.1.3/command.go:856 +0x2c2
github.com/spf13/cobra.(*Command).ExecuteC(0x2302ce0, 0xc00004a740, 0x1068aa8, 0xc000000180)
	github.com/spf13/cobra@v1.1.3/command.go:960 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.1.3/command.go:897
github.com/aws-cloudformation/rain/internal/cmd.execute(0x2302ce0, 0x0)
	github.com/aws-cloudformation/rain/internal/cmd/wrap.go:86 +0x65
github.com/aws-cloudformation/rain/internal/cmd.Execute(0x2302ce0)
	github.com/aws-cloudformation/rain/internal/cmd/wrap.go:95 +0x2b
main.main()
	command-line-arguments/main.go:23 +0x2d
```
test.yaml
```yaml
AWSTemplateFormatVersion: 2010-09-09
Resources:
  Param1:
    Type: AWS::SSM::Parameter
    Properties:
      Name: "Param1"
      Type: String
      Value: "value"
  Param2:
    Type: AWS::SSM::Parameter
    Properties:
      Name: "Param2"
      Type: String
      Value: !GetAtt Param1
```

*Description of changes:*
Fixed to return an error before referencing the array if `!GetAtt` is missing two required parameters and add error chains.
```
$ ./rain fmt test.yaml --debug
unable to parse input: GetAtt requires two parameters.
```

```go
+	if len(parts) != 2 {
+		return errors.New("GetAtt requires two parameters.")
+	}
```