### PR TITLE
build now omits the properties field in template if properties is empty

### DIFF
--- a/cft/build/build.go
+++ b/cft/build/build.go
@@ -98,10 +98,16 @@ func (b builder) newResource(resourceType string) (map[string]interface{}, []*cf
 		}
 	}
 
-	return map[string]interface{}{
+	resource := map[string]interface{}{
 		"Type":       resourceType,
 		"Properties": properties,
-	}, comments
+	}
+
+	if len(properties) == 0 {
+		delete(resource, "Properties")
+	}
+
+	return resource, comments
 }
 
 func (b builder) newProperty(resourceType, propertyName string, pSpec *spec.Property) (interface{}, []*cft.Comment) {

--- a/internal/cmd/build/build_test.go
+++ b/internal/cmd/build/build_test.go
@@ -22,5 +22,4 @@ func Example_build_bucket() {
 	// Resources:
 	//   MyBucket:
 	//     Type: AWS::S3::Bucket
-	//     Properties: {}
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* rain build will now omit the `Properties` field if it's empty. example:

before:

`rain build AWS::S3::Bucket -b`
```
AWSTemplateFormatVersion: "2010-09-09"

Description: Template generated by rain

Resources:
  MyBucket:
    Type: AWS::S3::Bucket
    Properties: {}
```

now:

`rain build AWS::S3::Bucket -b`
```
AWSTemplateFormatVersion: "2010-09-09"

Description: Template generated by rain

Resources:
  MyBucket:
    Type: AWS::S3::Bucket
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
