### PR TITLE
Removed SessionDuration to fix console bug

### DIFF
--- a/internal/aws/aws.go
+++ b/internal/aws/aws.go
@@ -80,15 +80,15 @@ func loadConfig(ctx context.Context, sessionName string) *aws.Config {
 		panic(errors.New("unable to find valid credentials"))
 	}
 
+	if cfg.Region == "" {
+		panic(errors.New("a region was not specified. You can run 'aws configure' or choose a profile with a region"))
+	}
+
 	// Check for validity
 	creds, err = cfg.Credentials.Retrieve(context.Background())
 	if err != nil {
 		config.Debugf("Error retreiving creds: %s", err.Error())
 		panic(errors.New("could not establish AWS credentials; please run 'aws configure' or choose a profile"))
-	}
-
-	if cfg.Region == "" {
-		panic(errors.New("a region was not specified. You can run 'aws configure' or choose a profile with a region"))
 	}
 
 	return &cfg

--- a/internal/aws/console/console.go
+++ b/internal/aws/console/console.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws-cloudformation/rain/internal/aws"
 	"github.com/aws-cloudformation/rain/internal/aws/cfn"
 	"github.com/aws-cloudformation/rain/internal/aws/sts"
+	"github.com/aws-cloudformation/rain/internal/config"
 	"github.com/aws/smithy-go/ptr"
 )
 
@@ -39,25 +40,51 @@ func buildSessionString(sessionName string) (string, error) {
 		sessionName = nameParts[1]
 	}
 
+	config.Debugf("sessionName: %v", sessionName)
+
 	creds, err := aws.NamedConfig(sessionName).Credentials.Retrieve(context.Background())
 	if err != nil {
 		return "", err
 	}
 
-	return url.QueryEscape(fmt.Sprintf(`{"sessionId": "%s", "sessionKey": "%s", "sessionToken": "%s"}`,
-		creds.AccessKeyID,
-		creds.SecretAccessKey,
-		creds.SessionToken,
-	)), nil
+	unescaped := fmt.Sprintf(`{"sessionId": "%s", "sessionKey": "%s", "sessionToken": "%s"}`,
+		creds.AccessKeyID, creds.SecretAccessKey, creds.SessionToken)
+
+	config.Debugf("unescaped session string: %v", unescaped)
+
+	return url.QueryEscape(unescaped), nil
 }
 
 func getSigninToken(userName string) (string, error) {
 	sessionString, err := buildSessionString(userName)
 	if err != nil {
+		config.Debugf("buildSessionString failed")
 		return "", err
 	}
+	config.Debugf("sessionString: %v", sessionString)
 
-	resp, err := http.Get(fmt.Sprintf("%s?Action=getSigninToken&Session=%s&SessionDuration=%d", signinURI, sessionString, sessionDuration))
+	// Broken with source_profile and a role arn in .aws/config
+	//uri := fmt.Sprintf("%s?Action=getSigninToken&Session=%s&SessionDuration=%d",
+	//	signinURI, sessionString, sessionDuration)
+
+	// Try it without session duration (console sessions will be limited to 1 hour)
+	uri := fmt.Sprintf("%s?Action=getSigninToken&Session=%s",
+		signinURI, sessionString)
+
+	// Looks like this is the problem. SessionDuration is only valid when AssumeRole
+	// is called, so when source_profile is used, it must cause a call to
+	// GetFederationToken, which would require the use of DurationSeconds.
+
+	config.Debugf("uri: %v", uri)
+
+	// This page provides a good explanation of what we're doing here:
+	// https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-custom-url.html
+
+	resp, err := http.Get(uri)
+	config.Debugf("resp.StatusCode: %v", resp.StatusCode)
+	if resp.StatusCode >= 300 && err == nil {
+		err = fmt.Errorf("Call to signin.aws.amazon.com resulted in a %v: %v", resp.StatusCode, resp.Status)
+	}
 	if err != nil {
 		return "", err
 	}
@@ -67,6 +94,8 @@ func getSigninToken(userName string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
+	config.Debugf("body: %s", body)
 
 	var out map[string]string
 	err = json.Unmarshal(body, &out)
@@ -84,10 +113,16 @@ func getSigninToken(userName string) (string, error) {
 
 // GetURI returns a sign-in uri for the current credentials and region
 func GetURI(service, stackName, userName string) (string, error) {
+
+	config.Debugf("GetURI %v, %v, %v", service, stackName, userName)
+
 	token, err := getSigninToken(userName)
 	if err != nil {
+		config.Debugf("getSigninToken failed")
 		return "", err
 	}
+
+	config.Debugf("token: %v", token)
 
 	if service == "" {
 		service = defaultService

--- a/internal/aws/console/console.go
+++ b/internal/aws/console/console.go
@@ -21,7 +21,8 @@ const signinURI = "https://signin.aws.amazon.com/federation"
 const issuer = "https://aws-cloudformation.github.io/rain/rain_console.html"
 const consoleURI = "https://console.aws.amazon.com"
 const defaultService = "cloudformation"
-const sessionDuration = 43200
+
+//const sessionDuration = 43200
 
 func buildSessionString(sessionName string) (string, error) {
 	if sessionName == "" {
@@ -83,7 +84,7 @@ func getSigninToken(userName string) (string, error) {
 	resp, err := http.Get(uri)
 	config.Debugf("resp.StatusCode: %v", resp.StatusCode)
 	if resp.StatusCode >= 300 && err == nil {
-		err = fmt.Errorf("Call to signin.aws.amazon.com resulted in a %v: %v", resp.StatusCode, resp.Status)
+		err = fmt.Errorf("call to signin.aws.amazon.com resulted in a %v: %v", resp.StatusCode, resp.Status)
 	}
 	if err != nil {
 		return "", err

--- a/internal/cmd/console/util.go
+++ b/internal/cmd/console/util.go
@@ -12,7 +12,7 @@ import (
 
 // Open generates a sign-in URL to the AWS console with an optional service and resource
 // If printOnly is true, the URL is printed to the console
-// If printOnly is fale, Open attempts to call the OS's browser with the URL
+// If printOnly is false, Open attempts to call the OS's browser with the URL
 func Open(printOnly bool, service, resource, userName string) {
 	spinner.Push("Generating sign-in URL")
 	uri, err := console.GetURI(service, resource, userName)

--- a/internal/config/version.go
+++ b/internal/config/version.go
@@ -5,5 +5,5 @@ const (
 	NAME = "Rain"
 
 	// VERSION is the application's version string
-	VERSION = "v1.3.0"
+	VERSION = "v1.3.3"
 )


### PR DESCRIPTION
Fixes #108. Removing `SessionDuration` from the call to get the session token if we get a 400 error from the endpoint.