### PR TITLE
Added helpful flags to pkg & merge commands

### DIFF
--- a/internal/aws/s3/mock.go
+++ b/internal/aws/s3/mock.go
@@ -10,6 +10,8 @@ import (
 	"github.com/aws-cloudformation/rain/internal/config"
 )
 
+var BucketName = ""
+var BucketKeyPrefix = ""
 var buckets = make(map[string]bool)
 
 // BucketExists checks whether the named bucket exists
@@ -37,7 +39,10 @@ func Upload(bucketName string, content []byte) (string, error) {
 // RainBucket returns the name of the rain deployment bucket in the current region
 // and creates it if it does not exist
 func RainBucket(forceCreation bool) string {
-	bucketName := fmt.Sprintf("rain-artifacts-1234567890-%s", aws.Config().Region)
+	bucketName := BucketName
+	if bucketName == "" {
+		bucketName = fmt.Sprintf("rain-artifacts-1234567890-%s", aws.Config().Region)
+	}
 
 	config.Debugf("Artifact bucket: %s", bucketName)
 

--- a/internal/cmd/merge/merge.go
+++ b/internal/cmd/merge/merge.go
@@ -2,6 +2,7 @@ package merge
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/aws-cloudformation/rain/cft"
 	"github.com/aws-cloudformation/rain/cft/format"
@@ -11,6 +12,7 @@ import (
 )
 
 var forceMerge = false
+var outFn = ""
 
 // Cmd is the merge command's entrypoint
 var Cmd = &cobra.Command{
@@ -45,10 +47,16 @@ var Cmd = &cobra.Command{
 			}
 		}
 
-		fmt.Println(format.String(merged, format.Options{}))
+		out := format.String(merged, format.Options{})
+		if outFn != "" {
+			os.WriteFile(outFn, []byte(out), 0644)
+		} else {
+			fmt.Println(out)
+		}
 	},
 }
 
 func init() {
+	Cmd.Flags().StringVarP(&outFn, "output", "o", "", "Output merged template to a file")
 	Cmd.Flags().BoolVarP(&forceMerge, "force", "f", false, "Don't warn on clashing attributes; rename them instead. Note: this will not rename Refs, GetAtts, etc.")
 }

--- a/internal/cmd/rain/rain.go
+++ b/internal/cmd/rain/rain.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aws-cloudformation/rain/internal/cmd/tree"
 	"github.com/aws-cloudformation/rain/internal/cmd/watch"
 	"github.com/aws-cloudformation/rain/internal/console"
+	"github.com/aws-cloudformation/rain/internal/aws/s3"
 )
 
 // Cmd is the rain command's entrypoint
@@ -59,7 +60,7 @@ Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
 const stackGroup = "Stack commands"
 const templateGroup = "Template commands"
 
-func addCommand(label string, profileOptions bool, c *cobra.Command) {
+func addCommand(label string, profileOptions, bucketOptions bool, c *cobra.Command) {
 	if label != "" {
 		c.Annotations = map[string]string{"Group": label}
 	}
@@ -69,31 +70,36 @@ func addCommand(label string, profileOptions bool, c *cobra.Command) {
 		c.Flags().StringVarP(&config.Region, "region", "r", "", "AWS region to use")
 	}
 
+	if bucketOptions {
+		c.Flags().StringVar(&s3.BucketName, "s3-bucket", "", "Name of the S3 bucket that is used to upload assets")
+		c.Flags().StringVar(&s3.BucketKeyPrefix, "s3-prefix", "", "Prefix to add to objects uploaded to S3 bucket")
+	}
+
 	Cmd.AddCommand(c)
 }
 
 func init() {
 	// Stack commands
-	addCommand(stackGroup, true, cat.Cmd)
-	addCommand(stackGroup, true, deploy.Cmd)
-	addCommand(stackGroup, true, logs.Cmd)
-	addCommand(stackGroup, true, ls.Cmd)
-	addCommand(stackGroup, true, rm.Cmd)
-	addCommand(stackGroup, true, watch.Cmd)
-	addCommand(stackGroup, true, stackset.StackSetCmd)
+	addCommand(stackGroup, true, false, cat.Cmd)
+	addCommand(stackGroup, true, true,  deploy.Cmd)
+	addCommand(stackGroup, true, false, logs.Cmd)
+	addCommand(stackGroup, true, false, ls.Cmd)
+	addCommand(stackGroup, true, false, rm.Cmd)
+	addCommand(stackGroup, true, false, watch.Cmd)
+	addCommand(stackGroup, true, false, stackset.StackSetCmd)
 
 	// Template commands
-	addCommand(templateGroup, false, build.Cmd)
-	addCommand(templateGroup, false, diff.Cmd)
-	addCommand(templateGroup, false, rainfmt.Cmd)
-	addCommand(templateGroup, false, merge.Cmd)
-	addCommand(templateGroup, true, pkg.Cmd)
-	addCommand(templateGroup, false, tree.Cmd)
-	addCommand(templateGroup, true, forecast.Cmd)
+	addCommand(templateGroup, false, false, build.Cmd)
+	addCommand(templateGroup, false, false, diff.Cmd)
+	addCommand(templateGroup, false, false, rainfmt.Cmd)
+	addCommand(templateGroup, false, false, merge.Cmd)
+	addCommand(templateGroup, true,  true,  pkg.Cmd)
+	addCommand(templateGroup, false, false, tree.Cmd)
+	addCommand(templateGroup, true,  false, forecast.Cmd)
 
 	// Other commands
-	addCommand("", true, consolecmd.Cmd)
-	addCommand("", true, info.Cmd)
+	addCommand("", true, false, consolecmd.Cmd)
+	addCommand("", true, false, info.Cmd)
 
 	// Customise usage
 	Cmd.Annotations = map[string]string{"Groups": fmt.Sprintf("%s|%s", stackGroup, templateGroup)}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Added optional `--s3-bucket` flag to `pkg` command. Would be used to specify an already created s3 bucket with a custom name.
- Added optional `--s3-prefix` flag to `pkg` command. Would be used to put assets into 'subfolders' within the s3 bucket.
- Added optional `--output` flag to `merge` command.

Mimicking `aws cloudformation package` command by adding `--s3-bucket` and `--s3-prefix` flags.

Not sure if these flags should be added to other commands but I added them to `rain pkg` and `rain deploy`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
