### PR TITLE
Implemented Rain::Env for pkg command

### DIFF
--- a/cft/pkg/pkg.go
+++ b/cft/pkg/pkg.go
@@ -5,6 +5,7 @@
 // or as one-property objects, much as AWS instrinsic functions are used, e.g. "Fn::Join"
 //
 // `Rain::Include`: insert the content of the file into the template directly. The file must be in YAML or JSON format.
+// `Rain::Env`: inserts environmental variable value into the template as a string. Variable must be set.
 // `Rain::Embed`: insert the content of the file as a string
 // `Rain::S3Http`: uploads the file or directory (zipping it first) to S3 and returns the HTTP URI (i.e. `https://bucket.s3.region.amazonaws.com/key`)
 // `Rain::S3`: a string value uploads the file or directory (zipping it first) to S3 and returns the S3 URI (i.e. `s3://bucket/key`)

--- a/cft/pkg/pkg_test.go
+++ b/cft/pkg/pkg_test.go
@@ -110,8 +110,26 @@ func TestInclude(t *testing.T) {
 			"Rain::Include": fileName,
 		},
 	})
-
 	compare(t, in, "Test", map[string]interface{}{"This": "is a test"})
+}
+
+func TestEnv(t *testing.T) {
+	os.Setenv("RAIN_TEST_ENV_EXISTS", "foo")
+	in1, _ := parse.Map(map[string]interface{}{
+		"Success": map[string]interface{}{
+			"Rain::Env": "RAIN_TEST_ENV_EXISTS",
+		},
+	})
+	in2, _ := parse.Map(map[string]interface{}{
+		"Failure": map[string]interface{}{
+			"Rain::Env": "RAIN_TEST_ENV_DOESNT_EXISTS",
+		},
+	})
+	compare(t, in1, "Success", "foo")
+	_, err2 := pkg.Template(in2, "./")
+	if err2 == nil {
+		t.Errorf("Expected error since %q environment variable doesn't exist", "RAIN_TEST_ENV_DOESNT_EXISTS")
+	}
 }
 
 func TestS3Http(t *testing.T) {

--- a/cft/pkg/util.go
+++ b/cft/pkg/util.go
@@ -5,6 +5,7 @@
 // or as one-property objects, much as AWS instrinsic functions are used, e.g. "Fn::Join"
 //
 // `Rain::Include`: insert the content of the file into the template directly. The file must be in YAML or JSON format.
+// `Rain::Env`: inserts environmental variable value into the template as a string. Variable must be set.
 // `Rain::Embed`: insert the content of the file as a string
 // `Rain::S3Http`: uploads the file or directory (zipping it first) to S3 and returns the HTTP URI (i.e. `https://bucket.s3.region.amazonaws.com/key`)
 // `Rain::S3`: a string value uploads the file or directory (zipping it first) to S3 and returns the S3 URI (i.e. `s3://bucket/key`)

--- a/cft/tags.go
+++ b/cft/tags.go
@@ -21,6 +21,7 @@ var Tags = map[string]string{
 	"!Condition":     "Condition",
 	"!Rain::Embed":   "Rain::Embed",
 	"!Rain::Include": "Rain::Include",
+	"!Rain::Env":     "Rain::Env",
 	"!Rain::S3Http":  "Rain::S3Http",
 	"!Rain::S3":      "Rain::S3",
 	"!Rain::Module":  "Rain::Module",

--- a/docs/rain_pkg.md
+++ b/docs/rain_pkg.md
@@ -12,6 +12,8 @@ You may use the following, rain-specific directives in templates packaged with "
 
   !Rain::Include <path>        Reads the file at <path> as YAML/JSON and inserts the resulting object into the template
 
+  !Rain::Env <name>            Reads the <name> environmental variable and inserts value into the template as a string
+
   !Rain::S3Http <path>         Uploads <path> (zipping first if it is a directory) to S3
                                and embeds the S3 HTTP URL into the template as a string
 

--- a/internal/aws/s3/mock.go
+++ b/internal/aws/s3/mock.go
@@ -5,6 +5,7 @@ package s3
 import (
 	"crypto/sha256"
 	"fmt"
+	"path/filepath"
 
 	"github.com/aws-cloudformation/rain/internal/aws"
 	"github.com/aws-cloudformation/rain/internal/config"
@@ -32,8 +33,7 @@ func Upload(bucketName string, content []byte) (string, error) {
 	if !isBucketExists {
 		return "", fmt.Errorf("bucket does not exist: '%s'", bucketName)
 	}
-
-	return fmt.Sprintf("%x", sha256.Sum256(content)), nil
+	return filepath.Join ( BucketKeyPrefix, fmt.Sprintf("%x", sha256.Sum256(content)) ), nil
 }
 
 // RainBucket returns the name of the rain deployment bucket in the current region

--- a/internal/aws/s3/s3_test.go
+++ b/internal/aws/s3/s3_test.go
@@ -1,0 +1,47 @@
+//go:build func_test
+
+package s3
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws-cloudformation/rain/internal/aws"
+)
+
+func TestPassingBucketName(t *testing.T) {
+	tests := [][]string {
+		{"custom-bucket-name", "custom-bucket-name"},
+		{"", fmt.Sprintf("rain-artifacts-1234567890-%s", aws.Config().Region) },
+	}
+	for _, test := range tests {
+		BucketName = test[0]
+		output := RainBucket(false)
+		if output != test[1] { 
+			t.Errorf("incorrect bucket name, expecting %q but got %q", test[1], output)
+		}
+	}
+}
+
+func TestPassingBucketKeyPrefix(t *testing.T) {
+	buckets ["random-bucket"] = true
+	content := []byte("some content")
+	hash := "290f493c44f5d63d06b374d0a5abd292fae38b92cab2fae5efefe1b0e9347f56"
+	tests := [][]string {
+		{"some-prefix",        fmt.Sprintf ("some-prefix/%s", hash)},
+		{"some-prefix/",       fmt.Sprintf ("some-prefix/%s", hash)},
+		{"some-prefix/test",   fmt.Sprintf ("some-prefix/test/%s", hash)},
+		{"some-prefix/test/",  fmt.Sprintf ("some-prefix/test/%s", hash)},
+		{"",                   hash},
+	}
+	for _, test := range tests {
+		BucketKeyPrefix = test[0]
+		output, err := Upload("random-bucket", content)
+		if err != nil {
+			t.Errorf("unexpected error during upload: %v", err)
+		}
+		if output != test[1] { 
+			t.Errorf("incorrect key, expecting %q but got %q", test[1], output)
+		}
+	}
+}

--- a/internal/cmd/pkg/pkg.go
+++ b/internal/cmd/pkg/pkg.go
@@ -29,6 +29,8 @@ You may use the following, rain-specific directives in templates packaged with "
 
   !Rain::Include <path>        Reads the file at <path> as YAML/JSON and inserts the resulting object into the template
 
+  !Rain::Env <name>            Reads the <name> environmental variable and inserts value into the template as a string
+
   !Rain::S3Http <path>         Uploads <path> (zipping first if it is a directory) to S3
                                and embeds the S3 HTTP URL into the template as a string
 


### PR DESCRIPTION
### Description of Changes:

I find it very useful to inject environmental variables into the template. Some use cases would include injecting a default AMI name into a template based on what environment the template is being packaged for (staging/production). For me this happens during CI/CD.

### Expected Behavior

The name of the environmental variable is passed as the only argument to `Rain::Env`.

If the environmental variable does not exist, then an error is returned, otherwise the value of the environmental variable is injected into the template as a string.

### Example

Given a file named `template.yaml` with the following contents:

```yaml
AWSTemplateFormatVersion: "2010-09-09"

Description: Template generated by rain

Parameters:
  ImageId:
    Type: String
    Default: !Rain::Env AMI_IMAGE

Resources:
  MyInstance:
    Type: AWS::EC2::Instance
    Properties:
      ImageId: !Ref ImageId
      InstanceType: c6g.xlarge
      # ...
```

Running the following command:

```shell
export AMI_IMAGE=ami-1234567890
rain pkg template.yml
```

Should result in a template that looks like this:

```yaml
AWSTemplateFormatVersion: "2010-09-09"

Description: Template generated by rain

Parameters:
  ImageId:
    Type: String
    Default: ami-1234567890

Resources:
  MyInstance:
    Type: AWS::EC2::Instance
    Properties:
      ImageId: !Ref ImageId
      InstanceType: c6g.xlarge
      # ...
```

### Additional Changes

I added some tests to for #136 as promised :)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
