### PR TITLE
Make AWS::CloudFormation::Interface metadata mergeable

### DIFF
--- a/internal/cmd/merge/merge_test.go
+++ b/internal/cmd/merge/merge_test.go
@@ -12,6 +12,25 @@ func TestMergeTemplatesSuccess(t *testing.T) {
 		"AWSTemplateFormatVersion": "overwritten",
 		"Description":              "Line 1",
 		"Metadata": map[string]interface{}{
+			"AWS::CloudFormation::Interface": map[string]interface{}{
+				"ParameterGroups": []interface{}{
+					map[string]interface{}{
+						"Label": map[string]interface{}{
+							"default": "Network Configuration",
+						},
+						"Parameters": []interface{}{
+							"VPCID",
+							"SubnetId",
+							"SecurityGroupID",
+						},
+					},
+				},
+				"ParameterLabels": map[string]interface{}{
+					"VPCID": map[string]interface{}{
+						"default": "Which VPC should this be deployed to?",
+					},
+				},
+			},
 			"Foo": "bar",
 		},
 		"Transform": "AWS::Serverless",
@@ -21,6 +40,25 @@ func TestMergeTemplatesSuccess(t *testing.T) {
 		"AWSTemplateFormatVersion": "ok to overwrite",
 		"Description":              "Line 2",
 		"Metadata": map[string]interface{}{
+			"AWS::CloudFormation::Interface": map[string]interface{}{
+				"ParameterGroups": []interface{}{
+					map[string]interface{}{
+						"Label": map[string]interface{}{
+							"default": "Amazon EC2 Configuration",
+						},
+						"Parameters": []interface{}{
+							"InstanceType",
+							"KeyName",
+						},
+					},
+				},
+				"ParameterLabels": map[string]interface{}{
+					"KeyName": map[string]interface{}{
+						"default": "EC2 Instance Ker Pair",
+					},
+				},
+			},
+
 			"Baz": "quux",
 		},
 		"Parameters": map[string]interface{}{
@@ -40,6 +78,37 @@ func TestMergeTemplatesSuccess(t *testing.T) {
 		"AWSTemplateFormatVersion": "ok to overwrite",
 		"Description":              "Line 1\nLine 2",
 		"Metadata": map[string]interface{}{
+			"AWS::CloudFormation::Interface": map[string]interface{}{
+				"ParameterGroups": []interface{}{
+					map[string]interface{}{
+						"Label": map[string]interface{}{
+							"default": "Network Configuration",
+						},
+						"Parameters": []interface{}{
+							"VPCID",
+							"SubnetId",
+							"SecurityGroupID",
+						},
+					},
+					map[string]interface{}{
+						"Label": map[string]interface{}{
+							"default": "Amazon EC2 Configuration",
+						},
+						"Parameters": []interface{}{
+							"InstanceType",
+							"KeyName",
+						},
+					},
+				},
+				"ParameterLabels": map[string]interface{}{
+					"VPCID": map[string]interface{}{
+						"default": "Which VPC should this be deployed to?",
+					},
+					"KeyName": map[string]interface{}{
+						"default": "EC2 Instance Ker Pair",
+					},
+				},
+			},
 			"Foo": "bar",
 			"Baz": "quux",
 		},

--- a/internal/cmd/merge/util.go
+++ b/internal/cmd/merge/util.go
@@ -61,6 +61,51 @@ func mergeTemplates(dstTemplate, srcTemplate cft.Template) (cft.Template, error)
 
 				dst[key] = append(dst[key].([]interface{}), src[key])
 			}
+
+		case "Metadata": // Combine metadata
+			dstMap := dst[key].(map[string]interface{})
+			srcMap := src[key].(map[string]interface{})
+			for k, _ := range srcMap {
+				if _, ok := dstMap[k]; !ok {
+					dstMap[k] = srcMap[k]
+				} else {
+					if k == "AWS::CloudFormation::Interface" {
+						dstInterface := dstMap[k].(map[string]interface{})
+						srcInterface := srcMap[k].(map[string]interface{})
+
+						// Concatenate ParameterGroups
+						if srcParameterGroups, ok := srcInterface["ParameterGroups"].([]interface{}); ok {
+							dstParameterGroups, ok := dstInterface["ParameterGroups"].([]interface{})
+							if !ok {
+								dstParameterGroups = srcParameterGroups
+							} else {
+								dstParameterGroups = append(dstParameterGroups, srcParameterGroups...)
+							}
+							dstInterface["ParameterGroups"] = dstParameterGroups
+						}
+						// Combine ParameterLabels
+						if _, ok := srcInterface["ParameterLabels"]; ok {
+							if err := checkMerge("ParameterLabels", dstInterface, srcInterface); err != nil {
+								return cft.Template{}, err
+							}
+						}
+					} else {
+						if forceMerge {
+							for i := 2; true; i++ {
+								newKey := fmt.Sprintf("%s_%d", k, i)
+								if _, ok := dstMap[newKey]; !ok {
+									k = newKey
+									break
+								}
+							}
+						} else {
+							return cft.Template{}, fmt.Errorf("templates have clashing %s: %s", key, k)
+						}
+						dstMap[k] = value
+					}
+				}
+			}
+
 		default:
 			err := checkMerge(key, dst, src)
 			if err != nil {


### PR DESCRIPTION
*Issue #, if available:*

Failed to merge [AWS::CloudFormation::Interface](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-interface.html) metadata and crashes
```
$ cat vpc.yaml
AWSTemplateFormatVersion: "2010-09-09"
Metadata:
  AWS::CloudFormation::Interface:
    ParameterGroups:
      -
        Label:
          default: "Network Configuration"
        Parameters:
          - VPCID
          - SubnetId
          - SecurityGroupID
    ParameterLabels:
      VPCID:
        default: "Which VPC should this be deployed to?"
$ cat instance.yaml
AWSTemplateFormatVersion: "2010-09-09"
Metadata:
  AWS::CloudFormation::Interface:
    ParameterGroups:
      -
        Label:
          default: "Amazon EC2 Configuration"
        Parameters:
          - InstanceType
          - KeyName
    ParameterLabels:
      KeyName:
        default: "EC2 Instance Ker Pair"
$ rain merge vpc.yaml instance.yaml
templates have clashing Metadata: AWS::CloudFormation::Interface
```

*Description of changes:*
Make only ParameterGroups, ParameterLabels in Metadata to be mergeable, and others crash or are forced to merge.

```
$ rain merge vpc.yaml instance.yaml
AWSTemplateFormatVersion: "2010-09-09"

Metadata:
  AWS::CloudFormation::Interface:
    ParameterGroups:
      - Label:
          default: Network Configuration
        Parameters:
          - VPCID
          - SubnetId
          - SecurityGroupID
      - Label:
          default: Amazon EC2 Configuration
        Parameters:
          - InstanceType
          - KeyName
    ParameterLabels:
      KeyName:
        default: EC2 Instance Ker Pair
      VPCID:
        default: Which VPC should this be deployed to?
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
