### PR TITLE
Metadata merge refactoring

### DIFF
--- a/internal/cmd/merge/merge_test.go
+++ b/internal/cmd/merge/merge_test.go
@@ -58,7 +58,6 @@ func TestMergeTemplatesSuccess(t *testing.T) {
 					},
 				},
 			},
-
 			"Baz": "quux",
 		},
 		"Parameters": map[string]interface{}{
@@ -136,6 +135,81 @@ func TestMergeTemplatesSuccess(t *testing.T) {
 	if d := cmp.Diff(actual.Map(), expected.Map()); d != "" {
 		t.Errorf(d)
 	}
+}
+
+func TestEmptyMergeTemplatesSuccess(t *testing.T) {
+	src, _ := parse.Map(map[string]interface{}{
+		"AWSTemplateFormatVersion": "ok to overwrite",
+		"Description":              "Line 2",
+		"Metadata": map[string]interface{}{
+			"AWS::CloudFormation::Interface": map[string]interface{}{
+				"ParameterGroups": []interface{}{
+					map[string]interface{}{
+						"Label": map[string]interface{}{
+							"default": "Amazon EC2 Configuration",
+						},
+						"Parameters": []interface{}{
+							"InstanceType",
+							"KeyName",
+						},
+					},
+				},
+				"ParameterLabels": map[string]interface{}{
+					"KeyName": map[string]interface{}{
+						"default": "EC2 Instance Ker Pair",
+					},
+				},
+			},
+
+			"Baz": "quux",
+		},
+		"Parameters": map[string]interface{}{
+			"Name": map[string]interface{}{
+				"Type": "String",
+			},
+		},
+		"Transform": map[string]interface{}{
+			"Name": "AWS::Include",
+			"Parameters": map[string]interface{}{
+				"Location": "Somewhere",
+			},
+		},
+		"Resources": map[string]interface{}{
+			"Type": "AWS::SSM::Parameter",
+			"Properties": map[string]interface{}{
+				"Name":  "test",
+				"Type":  "String",
+				"Value": "Value",
+			},
+		},
+	})
+
+	empty, _ := parse.Map(map[string]interface{}{})
+
+	// rain merge src.yaml /dev/null
+	{
+		actual, err := mergeTemplates(src, empty)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if d := cmp.Diff(actual.Map(), src.Map()); d != "" {
+			t.Errorf(d)
+		}
+	}
+
+	// rain merge /dev/null src.yaml
+	{
+		actual, err := mergeTemplates(empty, src)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if d := cmp.Diff(actual.Map(), src.Map()); d != "" {
+			t.Errorf(d)
+		}
+	}
+
 }
 
 func TestMergeTemplatesClash(t *testing.T) {


### PR DESCRIPTION
*Issue #, if available:*
Panic occurs due to lack of checking after type casting
```
$ cat ~/a.yaml
Metadata:
  Hoge: fuga
$ rain merge /dev/null ~/a.yaml --debug
panic: interface conversion: interface {} is nil, not map[string]interface {} [recovered]
	panic: interface conversion: interface {} is nil, not map[string]interface {}

goroutine 1 [running]:
github.com/aws-cloudformation/rain/internal/cmd.execute.func1()
	/Users/ugwis/GitHub/rain/internal/cmd/wrap.go:77 +0x176
panic({0x1a7d9e0, 0xc0009732c0})
	/usr/local/Cellar/go/1.20.3/libexec/src/runtime/panic.go:884 +0x213
github.com/aws-cloudformation/rain/internal/cmd/merge.mergeTemplates({0x7ff7bfeff945?}, {0xc0001d3d58?})
	/Users/ugwis/GitHub/rain/internal/cmd/merge/util.go:66 +0xdf6
github.com/aws-cloudformation/rain/internal/cmd/merge.glob..func1(0x2b85540?, {0xc000973020, 0x2, 0x3?})
	/Users/ugwis/GitHub/rain/internal/cmd/merge/merge.go:44 +0xfb
github.com/spf13/cobra.(*Command).execute(0x2b85540, {0xc000972ff0, 0x3, 0x3})
	/Users/ugwis/go/pkg/mod/github.com/spf13/cobra@v1.4.0/command.go:860 +0x663
github.com/spf13/cobra.(*Command).ExecuteC(0x2b85a40)
	/Users/ugwis/go/pkg/mod/github.com/spf13/cobra@v1.4.0/command.go:974 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/ugwis/go/pkg/mod/github.com/spf13/cobra@v1.4.0/command.go:902
github.com/aws-cloudformation/rain/internal/cmd.execute(0x0?)
	/Users/ugwis/GitHub/rain/internal/cmd/wrap.go:86 +0x65
github.com/aws-cloudformation/rain/internal/cmd.Execute(0xc0000061a0?)
	/Users/ugwis/GitHub/rain/internal/cmd/wrap.go:95 +0x19
main.main()
	/Users/ugwis/GitHub/rain/cmd/rain/main.go:23 +0x25
```

*Description of changes:*
- Add check after type casting
- Add unit-test for force merge
- Add unit-test merge with empty template

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
