### PR TITLE
fix: panic when no changes in the resources of the nested ChangeSet

### DIFF
--- a/internal/cmd/deploy/util.go
+++ b/internal/cmd/deploy/util.go
@@ -58,7 +58,11 @@ func formatChangeSet(stackName, changeSetName string) string {
 
 		child := formatChangeSet("", ptr.ToString(change.ResourceChange.ChangeSetId))
 		parts := strings.SplitN(child, "\n", 2)
-		header, body := parts[0], parts[1]
+		header := parts[0]
+		body := console.Grey("    (no changes in resources)\n")
+		if len(parts) == 2 {
+			body = parts[1]
+		}
 
 		switch change.ResourceChange.Action {
 		case types.ChangeAction("Add"):


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-cloudformation/rain/issues/152

*Description of changes:*
Print `no changes in resources` only when no changes in the resource of the nested stack

![Screenshot 2023-06-15 at 0 18 34](https://github.com/aws-cloudformation/rain/assets/914815/827e25d9-3722-4702-8a58-a934e7fe18a7)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
