### PR TITLE
fix: bugs in stack and stacksets deployment

### DIFF
--- a/internal/aws/cfn/cfn.go
+++ b/internal/aws/cfn/cfn.go
@@ -512,6 +512,9 @@ func CreateStackSet(conf StackSetConfig) (*string, error) {
 
 	res, err := getClient().CreateStackSet(context.Background(), input)
 
+	if err != nil {
+		return nil, err
+	}
 	return res.StackSetId, err
 }
 

--- a/internal/aws/cfn/mock.go
+++ b/internal/aws/cfn/mock.go
@@ -180,7 +180,8 @@ func CreateChangeSet(template cft.Template, params []types.Parameter, tags map[s
 		roleArn:   roleArn,
 	}
 	if stackName == "emptychangeset" {
-		return name, fmt.Errorf("%so updates are to be performed%s", "N", ".")
+		//lint:ignore ST1005 we want to create errors with upper case and punctuation for mock
+		return name, fmt.Errorf("No updates are to be performed.")
 	}
 
 	return name, nil

--- a/internal/aws/cfn/mock.go
+++ b/internal/aws/cfn/mock.go
@@ -179,6 +179,9 @@ func CreateChangeSet(template cft.Template, params []types.Parameter, tags map[s
 		stackName: stackName,
 		roleArn:   roleArn,
 	}
+	if stackName == "emptychangeset" {
+		return name, fmt.Errorf("%so updates are to be performed%s", "N", ".")
+	}
 
 	return name, nil
 }

--- a/internal/aws/cfn/mock.go
+++ b/internal/aws/cfn/mock.go
@@ -180,7 +180,7 @@ func CreateChangeSet(template cft.Template, params []types.Parameter, tags map[s
 		roleArn:   roleArn,
 	}
 	if stackName == "emptychangeset" {
-		return name, fmt.Errorf("%no updates are to be performed%s", "N", ".")
+		return name, fmt.Errorf("%so updates are to be performed%s", "N", ".")
 	}
 
 	return name, nil

--- a/internal/aws/cfn/mock.go
+++ b/internal/aws/cfn/mock.go
@@ -180,7 +180,7 @@ func CreateChangeSet(template cft.Template, params []types.Parameter, tags map[s
 		roleArn:   roleArn,
 	}
 	if stackName == "emptychangeset" {
-		return name, fmt.Errorf("%so updates are to be performed%s", "N", ".")
+		return name, fmt.Errorf("%no updates are to be performed%s", "N", ".")
 	}
 
 	return name, nil

--- a/internal/cmd/deploy/deploy.go
+++ b/internal/cmd/deploy/deploy.go
@@ -15,8 +15,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const noChangeFoundMsg = "The submitted information didn't contain changes. Submit different information to create a change set."
-
 var detach bool
 var yes bool
 var params []string
@@ -98,7 +96,7 @@ YAML:
 		spinner.Push("Creating change set")
 		changeSetName, createErr := cfn.CreateChangeSet(template, dc.Params, dc.Tags, stackName, roleArn)
 		if createErr != nil {
-			if createErr.Error() == noChangeFoundMsg {
+			if changeSetHasNoChanges(createErr.Error()) {
 				spinner.Pop()
 				fmt.Println(console.Green("Change set was created, but there is no change. Deploy was skipped."))
 				return
@@ -175,6 +173,20 @@ YAML:
 			}
 		}
 	},
+}
+
+func changeSetHasNoChanges(msg string) bool {
+	// mesages returned as error when the change set is empty
+	noChangeFoundMsg := []string{
+		"The submitted information didn't contain changes. Submit different information to create a change set.",
+		"No updates are to be performed.",
+	}
+	for _, m := range noChangeFoundMsg {
+		if m == msg {
+			return true
+		}
+	}
+	return false
 }
 
 func init() {

--- a/internal/cmd/deploy/deploy.go
+++ b/internal/cmd/deploy/deploy.go
@@ -173,6 +173,9 @@ YAML:
 			}
 		}
 	},
+	PostRun: func(cmd *cobra.Command, args []string) {
+		params = nil
+	},
 }
 
 func changeSetHasNoChanges(msg string) bool {

--- a/test/func_test.go
+++ b/test/func_test.go
@@ -77,6 +77,15 @@ Stack success: CREATE_COMPLETE
     MockKey: Mock value # Mock output description (exported as MockExport)
 Successfully deployed success
 `, "", 0)
+	wrap(t, []string{
+		"deploy",
+		"-y",
+		"-t",
+		"--params",
+		"BucketName=foo",
+		"templates/emptychangeset.template",
+	}, `Change set was created, but there is no change. Deploy was skipped.
+`, "", 0)
 
 	// Cat
 	wrap(t, []string{

--- a/test/templates/emptychangeset.template
+++ b/test/templates/emptychangeset.template
@@ -1,0 +1,9 @@
+Description: This template succeeds
+Parameters:
+  BucketName:
+    Type: String
+Resources:
+  Bucket1:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Ref BucketName


### PR DESCRIPTION
*Description of changes: Bug fixes for stack and stack-set deployment*

- *Bug 1*(Line 101 of internal/cmd/deploy/deploy.go) : deploying a stack with no changes causes an the cli to throw an error with the message "No updates are to be performed."; fixed it by added new messages and overhauling the checking method

- *Bug 2*(Line 515 of internal/aws/cfn/cfn.go) : error handling in the cfn module, causes the cli to panic if there is an error in the stackset template; fixed it by handling it correctly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
