### PR TITLE
fix: support literal with chomping indicator

### DIFF
--- a/cft/format/format.go
+++ b/cft/format/format.go
@@ -3,6 +3,7 @@
 package format
 
 import (
+	"regexp"
 	"strings"
 
 	"github.com/aws-cloudformation/rain/cft"
@@ -19,6 +20,13 @@ type Options struct {
 	// If false, the formatter will rearrange the template elements into
 	// canonical order.
 	Unsorted bool
+}
+
+func CheckMultilineBegin(s string) bool {
+	// Match block header
+	// https://yaml.org/spec/1.2.2/#8112-block-chomping-indicator
+	r, _ := regexp.Compile("[|>](([0-9]*[+-])|([+-][0-9]*))?$")
+	return r.MatchString(s)
 }
 
 // String returns a string representation of the supplied cft.Template
@@ -70,7 +78,7 @@ func String(t cft.Template, opt Options) string {
 			}
 		}
 		trimmedRight := strings.TrimRight(part, " ")
-		if strings.HasSuffix(trimmedRight, "|") || strings.HasSuffix(trimmedRight, ">") {
+		if CheckMultilineBegin(trimmedRight) {
 			startMultilineIndent = indent
 		}
 

--- a/cft/format/format_test.go
+++ b/cft/format/format_test.go
@@ -1,6 +1,7 @@
 package format_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/aws-cloudformation/rain/cft/format"
@@ -383,6 +384,35 @@ const expectedUnsortedJson = `{
 }
 `
 
+const correctMultilineBlockHeaders = `
+|+
+|2+
+|+2
+|-
+|2-
+|-2
+>+
+>2+
+>+2
+>-
+>2-
+>-2
+|10+
+|+10
+>10+
+>+10
+`
+
+const wrongMultilineBlockHeaders = `
+|2+2
+>2+2
+|+2+
+>+2+
+|++
+>++
+>2+ a
+`
+
 func checkMatch(t *testing.T, expected string, opt format.Options) {
 	template, err := parse.String(input)
 	if err != nil {
@@ -393,6 +423,18 @@ func checkMatch(t *testing.T, expected string, opt format.Options) {
 
 	if d := cmp.Diff(expected, actual); d != "" {
 		t.Errorf(d)
+	}
+}
+
+func checkMultilineBlockHeaders(t *testing.T, s string, expected bool) {
+	parts := strings.Split(s, "\n")
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		if format.CheckMultilineBegin(part) != expected {
+			t.Errorf(part)
+		}
 	}
 }
 
@@ -408,4 +450,6 @@ func TestFormatDefault(t *testing.T) {
 		JSON:     true,
 		Unsorted: true,
 	})
+	checkMultilineBlockHeaders(t, correctMultilineBlockHeaders, true)
+	checkMultilineBlockHeaders(t, wrongMultilineBlockHeaders, false)
 }


### PR DESCRIPTION
*Issue #110, if available:*
Sometimes YAML package generates multiline strings with chomping (e.g. |2+), but the rain format post-processing seems to ignore this.

*Description of changes:*
Change from an exact match of `|` or `>` to a regex match that complies with YAML spec.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
