### PR TITLE
add: show formatted output with debugging

### DIFF
--- a/internal/cmd/fmt/fmt.go
+++ b/internal/cmd/fmt/fmt.go
@@ -54,6 +54,7 @@ func formatReader(name string, r io.Reader) result {
 
 	// Verify the output is valid
 	if err = parse.Verify(source, res.output); err != nil {
+		config.Debugf("formatted output:\n%s\n", res.output)
 		res.err = err
 		return res
 	}


### PR DESCRIPTION
*Issue #196, if available:*

*Description of changes:*
When rain fmt `parse.Verify` fails, show formatted output with --debug


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
