### PR TITLE
ci: Align release artifacts with Go naming for Mac

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -2,8 +2,8 @@
 
 set -eou pipefail
 
-declare -a platforms=(linux/amd64 linux/386 linux/arm darwin/amd64 windows/amd64 windows/386)
-declare -A mapping=([darwin]=macos [linux]=linux [windows]=windows [amd64]=amd64 [386]=i386 [arm]=arm)
+declare -a platforms=(linux/amd64 linux/386 linux/arm darwin/amd64 darwin/arm64 windows/amd64 windows/386)
+declare -A mapping=([darwin]=darwin [linux]=linux [windows]=windows [amd64]=amd64 [386]=i386 [arm]=arm [arm64]=arm64)
 declare -a CGO=(0 1)
 
 for platform in "${platforms[@]}"; do

--- a/internal/config/version.go
+++ b/internal/config/version.go
@@ -5,5 +5,5 @@ const (
 	NAME = "Rain"
 
 	// VERSION is the application's version string
-	VERSION = "v1.5.0"
+	VERSION = "v1.6.0"
 )


### PR DESCRIPTION
*Issue #, if available:*  aws-cloudformation/rain#151 and aws-cloudformation/rain#201

*Description of changes:* Changes release artifact naming for Mac to align with Go naming with the use of `darwin` instead of `macos`.  Additionally, adds building `darwin/arm64` for Apple silicon.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
