### PR TITLE
fix: support IAM user identity in GetCallerArn

### DIFF
--- a/internal/aws/iam/iam_test.go
+++ b/internal/aws/iam/iam_test.go
@@ -1,0 +1,12 @@
+package iam
+
+import "testing"
+
+func TestTransformCallerArn2(t *testing.T) {
+	if TransformCallerArn("arn:aws:sts::755952356119:assumed-role/Admin/khmoryz") != "arn:aws:iam::755952356119:role/Admin" {
+		t.Errorf("Failed to transform assume-role type arn")
+	}
+	if TransformCallerArn("arn:aws:iam::755952356119:user/khmoryz") != "arn:aws:iam::755952356119:user/khmoryz" {
+		t.Errorf("Failed to transform IAM user type arn")
+	}
+}


### PR DESCRIPTION
## Overview

Changed the ARN returned by GetCallerIdentity to return the IAM Role ARN if it is of the "assume-role" style, otherwise the ARN is returned as is.

## Issue

#216 

## Check

**IAM user**

```sh
$ aws sts get-caller-identity
{
    "UserId": "xxxxxxxxxxxxxxxxxxxxx",
    "Account": "xxxxxxxxxxxx",
    "Arn": "arn:aws:iam::xxxxxxxxxxxx:user/khrmoryz"
}

$ go run cmd/rain/main.go forecast --experimental ./test/templates/success.template s3 --params BucketName=foo
Clear skies! 🌞 All 3 checks passed.
```

**Assume-Role**

```sh
$ aws sts get-caller-identity
{
    "UserId": "xxxxxxxxxxxxxxxxxxxxx:botocore-session-1701516435",
    "Account": "xxxxxxxxxxxx",
    "Arn": "arn:aws:sts::xxxxxxxxxxxx:assumed-role/Admin/botocore-session-1701516435"
}

$ go run cmd/rain/main.go forecast --experimental ./test/templates/success.template s3 --params BucketName=foo
Clear skies! 🌞 All 3 checks passed.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
