### PR TITLE
Fix:update specification of claude v2 modelid

### DIFF
--- a/internal/aws/bedrock/bedrock.go
+++ b/internal/aws/bedrock/bedrock.go
@@ -29,7 +29,7 @@ func getClient() *bedrockruntime.Client {
 
 const (
 	claudePromptFormat = "\n\nHuman:%s\n\nAssistant:"
-	claudeV2ModelID    = "anthropic.claude-v2"
+	claudeV2ModelID    = "anthropic.claude-v2:1"
 )
 
 // Invoke invokes the Claude V2 model with the provided prompt.


### PR DESCRIPTION
*Issue https://github.com/aws-cloudformation/rain/issues/235, if available:*

*Description of changes:*



In attempting to correct this, 
I assume this part 

https://github.com/aws-cloudformation/rain/blob/10c3391e327fd62504b9cd954a5a33428a0f5fb5/internal/aws/bedrock/bedrock.go#L30-L33

could be modified by specifying `:1` at the end of `claudeV2ModelID` as follows

```
const (
	claudePromptFormat = "\n\nHuman:%s\n\nAssistant:"
	claudeV2ModelID    = "anthropic.claude-v2:1"
)
```




When I tried the modified one, it actually worked like this

```
$ ./rain build -p "VPC with 1 private and 1 public subnet"
AWSTemplateFormatVersion: '2010-09-09'
Description: VPC with 1 public and 1 private subnet

Resources:

  VPC:
    Type: AWS::EC2::VPC
    Properties:
      CidrBlock: 10.0.0.0/16
      EnableDnsSupport: true
      EnableDnsHostnames: true
  
  PublicSubnet:
    Type: AWS::EC2::Subnet
    Properties:
      VpcId: !Ref VPC
      CidrBlock: 10.0.1.0/24
      MapPublicIpOnLaunch: true
  
  PrivateSubnet:
    Type: AWS::EC2::Subnet
    Properties: 
      VpcId: !Ref VPC
      CidrBlock: 10.0.2.0/24
```

reference:
https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids-arns.html#:~:text=anthropic.claude%2Dv2.%20For%20Claude%202.1%2C%20use%20anthropic.claude%2Dv2%3A1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
