### PR TITLE
Fix formatting round trip - Style is always 0

### DIFF
--- a/cft/format/format_test.go
+++ b/cft/format/format_test.go
@@ -107,7 +107,7 @@ Resources:
   Func1:
     Type: AWS::Lambda::Function
     Properties:
-      Role: !Sub "arn:aws:iam::${AWS::AccountID}:role/lambda-basic"
+      Role: !Sub arn:aws:iam::${AWS::AccountID}:role/lambda-basic
       Runtime: python3.7
       Handler: index.handler
       Code:
@@ -158,7 +158,7 @@ Resources:
   Func1:
     Type: AWS::Lambda::Function
     Properties:
-      Role: !Sub "arn:aws:iam::${AWS::AccountID}:role/lambda-basic"
+      Role: !Sub arn:aws:iam::${AWS::AccountID}:role/lambda-basic
       Runtime: python3.7
       Handler: index.handler
       Code:
@@ -439,19 +439,34 @@ func checkMultilineBlockHeaders(t *testing.T, s string, expected bool) {
 	}
 }
 
-func TestFormatDefault(t *testing.T) {
+func TestFormatYaml(t *testing.T) {
 	checkMatch(t, expectedYaml, format.Options{})
+}
+
+func TestFormatYamlUnsorted(t *testing.T) {
 	checkMatch(t, expectedYamlUnsorted, format.Options{
 		Unsorted: true,
 	})
+}
+
+func TestFormatJson(t *testing.T) {
 	checkMatch(t, expectedJson, format.Options{
 		JSON: true,
 	})
+}
+
+func TestFormatUnsortedJson(t *testing.T) {
 	checkMatch(t, expectedUnsortedJson, format.Options{
 		JSON:     true,
 		Unsorted: true,
 	})
+}
+
+func TestFormatMultiLineBlock(t *testing.T) {
 	checkMultilineBlockHeaders(t, correctMultilineBlockHeaders, true)
+}
+
+func TestFormatMultiLineBlockWrong(t *testing.T) {
 	checkMultilineBlockHeaders(t, wrongMultilineBlockHeaders, false)
 }
 
@@ -504,7 +519,10 @@ Resources:
   Topic:
     Type: AWS::SNS::Topic
     Properties:
-      TopicName: !FindInMap [EnvironmentMap, MappedParam, !Ref EnvironmentParam]
+      TopicName: !FindInMap
+        - EnvironmentMap
+        - MappedParam
+        - !Ref EnvironmentParam
 `
 
 	template, err := parse.String(yaml)

--- a/cft/format/transform.go
+++ b/cft/format/transform.go
@@ -92,5 +92,8 @@ func formatNode(n *yaml.Node) *yaml.Node {
 		n.Content[i] = formatNode(child)
 	}
 
+	// Always set Style to 0 for consistent formatting
+	n.Style = 0
+
 	return n
 }

--- a/test/templates/fmttestinput.yaml
+++ b/test/templates/fmttestinput.yaml
@@ -1,0 +1,61 @@
+Outputs:
+  Bucket1:
+    Value: !GetAtt Bucket1.Arn # Short GetAtt
+  Bucket2: # Bucket comment
+    Value:
+      Fn::GetAtt: # GetAtt comment
+        - Bucket2
+        - Arn # Arn comment
+
+Description: |
+  An example template for testing rain fmt command.
+
+# Multiline comment
+# starting at indent 0
+Resources:
+  Bucket2:
+    Properties:
+      BucketName: !Ref Name # Ref: comment
+    Type: "AWS::S3::Bucket"
+  Bucket1:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub ${Bucket2}-newer
+  Func1:
+    Type: AWS::Lambda::Function
+    Properties:
+      Role: !Sub "arn:aws:iam::${AWS::AccountID}:role/lambda-basic"
+      Runtime: python3.7
+      Handler: index.handler
+      Code:
+        ZipFile: |
+          import boto3
+
+          def handler: 
+            """Example."""
+
+            print('hello')
+  Instance1:
+    Type: AWS::EC2::Instance
+    Properties:
+      UserData: !Base64
+        Fn::Sub:
+          - |
+            #!/bin/bash -xe
+            apt-get update
+
+            apt-get upgrade -y
+Rules:
+  Rule1:
+    RuleCondition: !Equals
+      - !Ref Environment
+      - test
+    Assertions:
+      - Assert:
+          Fn::Contains:
+            - - a1.medium
+            - !Ref InstanceType
+Parameters:
+  Name:
+    Type: String
+

--- a/test/templates/roundtrip.yaml
+++ b/test/templates/roundtrip.yaml
@@ -1,0 +1,12 @@
+Parameters:
+  RootId:
+    Type: String
+
+Resources:
+
+  Sandbox:
+    Type: AWS::Organizations::OrganizationalUnit
+    Properties:
+      ParentId: !Ref RootId
+      Name: Sandbox
+


### PR DESCRIPTION
When formatting to JSON and back to YAML, JSON styles were left in the YAML nodes, which caused inconsistent formatting.

This *might* be considered a breaking change, because one of the effects is to now format `!Sub` without double quotes, even if they were in the original.

Fixes #170
