### PR TITLE
Fixed template packaging to resolve anchors

### DIFF
--- a/cft/pkg/anchor_test.go
+++ b/cft/pkg/anchor_test.go
@@ -1,0 +1,33 @@
+package pkg
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestAnchors(t *testing.T) {
+	source := "./tmpl/anchors.yaml"
+	template, err := File(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected, err := File("./tmpl/anchors-expect.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// This actually succeeds, because the diff package uses YAML decoding
+	// to make the comparison, and the yaml package understands anchors
+	//d := diff.New(template, expected)
+	//if d.Mode() != "=" {
+	//	t.Errorf("template does not match expected: %v", d.Format(true))
+	//}
+
+	// This correctly shows differences in the templates
+	if d := cmp.Diff(expected, template); d != "" {
+		t.Error(d)
+	}
+
+}

--- a/cft/pkg/pkg.go
+++ b/cft/pkg/pkg.go
@@ -25,7 +25,6 @@
 package pkg
 
 import (
-	"encoding/json"
 	"path/filepath"
 
 	"github.com/aws-cloudformation/rain/cft"
@@ -67,16 +66,16 @@ func transform(nodeToTransform *yaml.Node, rootDir string, t cft.Template, paren
 func Template(t cft.Template, rootDir string) (cft.Template, error) {
 	templateNode := t.Node
 
-	j, _ := json.MarshalIndent(t.Node, "", "  ")
-	config.Debugf("Original template: %v", string(j))
+	// j, _ := json.MarshalIndent(t.Node, "", "  ")
+	// config.Debugf("Original template: %v", string(j))
 
 	changed, err := transform(templateNode, rootDir, t, nil)
 	if err != nil {
 		return t, err
 	}
 
-	j, _ = json.MarshalIndent(templateNode, "", "  ")
-	config.Debugf("Transformed template: %v", string(j))
+	// j, _ = json.MarshalIndent(templateNode, "", "  ")
+	// config.Debugf("Transformed template: %v", string(j))
 
 	if changed {
 		t, err = parse.Node(templateNode)
@@ -85,7 +84,7 @@ func Template(t cft.Template, rootDir string) (cft.Template, error) {
 		}
 	}
 
-	// Encode and Decode to resolve anchors... ?
+	// Encode and Decode to resolve anchors
 	var decoded interface{}
 	err = templateNode.Decode(&decoded)
 	if err != nil {

--- a/cft/pkg/tmpl/anchors-expect.yaml
+++ b/cft/pkg/tmpl/anchors-expect.yaml
@@ -1,19 +1,20 @@
 Resources:
   MyLambda:
     Type: AWS::Lambda::Function
+    Metadata:
+      Comment:
+        ZipFile: |
+          print("Hello World!")
     Properties:
       Code:
-        ZipFile: "print(\"Hello World!\")\n"
+        ZipFile: |
+          print("Hello World!")
       FunctionName: my-lambda
       Handler: index.lambda_handler
-      Role:
-        Fn::ImportValue: MyLambdaRoleArn
+      Role: !ImportValue MyLambdaRoleArn
       Runtime: python3.8
       Tags:
-      - Key: foo
-        Value: myval
-      - Key: bar
-        Value: myval
-      - Key: baz
-        Value:
-          ZipFile: "print(\"Hello World!\")\n"
+        - Key: foo
+          Value: myval
+        - Key: bar
+          Value: myval

--- a/cft/pkg/tmpl/anchors-expect.yaml
+++ b/cft/pkg/tmpl/anchors-expect.yaml
@@ -1,0 +1,19 @@
+Resources:
+  MyLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        ZipFile: "print(\"Hello World!\")\n"
+      FunctionName: my-lambda
+      Handler: index.lambda_handler
+      Role:
+        Fn::ImportValue: MyLambdaRoleArn
+      Runtime: python3.8
+      Tags:
+      - Key: foo
+        Value: myval
+      - Key: bar
+        Value: myval
+      - Key: baz
+        Value:
+          ZipFile: "print(\"Hello World!\")\n"

--- a/cft/pkg/tmpl/anchors.yaml
+++ b/cft/pkg/tmpl/anchors.yaml
@@ -1,0 +1,18 @@
+Resources:
+  MyLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code: &code
+        ZipFile: "print(\"Hello World!\")\n"
+      FunctionName: my-lambda
+      Handler: index.lambda_handler
+      Role: !ImportValue 'MyLambdaRoleArn'
+      Runtime: python3.8
+      Tags:
+        - Key: foo
+          Value: &fooval myval
+        - Key: bar
+          Value: *fooval
+        - Key: baz
+          Value: *code
+

--- a/cft/pkg/tmpl/anchors.yaml
+++ b/cft/pkg/tmpl/anchors.yaml
@@ -13,6 +13,6 @@ Resources:
           Value: &fooval myval
         - Key: bar
           Value: *fooval
-        - Key: baz
-          Value: *code
+    Metadata:
+      Comment: *code
 


### PR DESCRIPTION
Fixes #257 

Instead of using just the `fmt` command, first `pkg` and then pipe into `fmt`.

Going to leave this a draft for now. All tests are passing but there are some templates with anchors that will cause `fmt` to fail, which means you would have to package first. That may be unexpected for some users, although the anchors would fail when you send them to CloudFormation, so maybe it doesn't matter. The issue is due to default sorting, which puts the anchors out of order and the go yaml parser can't resolve them. Maybe that's ok? If you want to format a template with anchors you can add `--unsorted` and it will work.

@hariprakash-j, @khmoryz, @null93, @iainelder 
@j5nb4l 

