### PR TITLE
Added a `cc drift` command that detects and remediates drift

### DIFF
--- a/cft/cft.go
+++ b/cft/cft.go
@@ -60,6 +60,7 @@ const (
 	Conditions               Section = "Conditions"
 	Transform                Section = "Transform"
 	Outputs                  Section = "Outputs"
+	State                    Section = "State"
 )
 
 // GetResource returns the yaml node for a resource by logical id
@@ -112,4 +113,13 @@ func (t Template) AddMapSection(section Section) (*yaml.Node, error) {
 
 	m := t.Node.Content[0]
 	return node.AddMap(m, string(section)), nil
+}
+
+// GetSection returns the yaml node for the section
+func (t Template) GetSection(section Section) (*yaml.Node, error) {
+	_, s := s11n.GetMapValue(t.Node.Content[0], string(section))
+	if s == nil {
+		return nil, fmt.Errorf("unable to locate the %s node", section)
+	}
+	return s, nil
 }

--- a/cft/diff/compare.go
+++ b/cft/diff/compare.go
@@ -9,7 +9,7 @@ import (
 
 // New returns a Diff that represents the difference between two templates
 func New(a, b cft.Template) Diff {
-	return compareMaps(a.Map(), b.Map())
+	return CompareMaps(a.Map(), b.Map())
 }
 
 func compareValues(old, new interface{}) Diff {
@@ -21,7 +21,7 @@ func compareValues(old, new interface{}) Diff {
 	case []interface{}:
 		return compareSlices(v, new.([]interface{}))
 	case map[string]interface{}:
-		return compareMaps(v, new.(map[string]interface{}))
+		return CompareMaps(v, new.(map[string]interface{}))
 	default:
 		if !reflect.DeepEqual(old, new) {
 			return value{new, Changed}
@@ -48,7 +48,7 @@ func compareSlices(old, new []interface{}) Diff {
 	return d
 }
 
-func compareMaps(old, new map[string]interface{}) Diff {
+func CompareMaps(old, new map[string]interface{}) Diff {
 	d := make(dmap)
 
 	// New and updated keys

--- a/cft/parse/parse.go
+++ b/cft/parse/parse.go
@@ -46,19 +46,19 @@ func Map(input map[string]interface{}) (cft.Template, error) {
 
 // String returns a cft.Template parsed from a string
 func String(input string) (cft.Template, error) {
-	var node yaml.Node
-	err := yaml.Unmarshal([]byte(input), &node)
+	var n yaml.Node
+	err := yaml.Unmarshal([]byte(input), &n)
 	if err != nil {
 		return cft.Template{}, fmt.Errorf("invalid YAML: %s", err)
 	}
 
-	return Node(&node)
+	return Node(&n)
 }
 
 // Node returns a cft.Template parse from a *yaml.Node
-func Node(node *yaml.Node) (cft.Template, error) {
-	err := TransformNode(node)
-	return cft.Template{Node: node}, err
+func Node(n *yaml.Node) (cft.Template, error) {
+	err := TransformNode(n)
+	return cft.Template{Node: n}, err
 }
 
 // Verify confirms that there is no semantic difference between

--- a/cft/pkg/pkg.go
+++ b/cft/pkg/pkg.go
@@ -90,14 +90,18 @@ func Template(t cft.Template, rootDir string) (cft.Template, error) {
 	if err != nil {
 		return t, err
 	}
-	config.Debugf("decoded: %v", decoded)
 
 	err = templateNode.Encode(&decoded)
 	if err != nil {
 		return t, err
 	}
 
-	return t, err
+	// We lose the Document node here
+	retval := cft.Template{}
+	retval.Node = &yaml.Node{Kind: yaml.DocumentNode, Content: make([]*yaml.Node, 0)}
+	retval.Node.Content = append(retval.Node.Content, templateNode)
+
+	return retval, err
 }
 
 // File opens path as a CloudFormation template and returns a cft.Template

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/lightsail v1.34.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.21.7 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/manifoldco/promptui v0.9.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -48,10 +48,13 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.26.7 h1:NzO4Vrau795RkUdSHKEwiR01FaGz
 github.com/aws/aws-sdk-go-v2/service/sts v1.26.7/go.mod h1:6h2YuIoxaMSCFf5fi1EgZAwdfkGMgDY+DVfa61uLe4U=
 github.com/aws/smithy-go v1.19.0 h1:KWFKQV80DpP3vJrrA9sVAHQ5gc2z8i4EzrLhLlWXcBM=
 github.com/aws/smithy-go v1.19.0/go.mod h1:NukqUGpCZIILqqiV0NIjeFh24kd/FAa4beRb6nbIUPE=
+github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/logex v1.2.1 h1:XHDu3E6q+gdHgsdTPH6ImJMIp436vR6MPtH8gP05QzM=
 github.com/chzyer/logex v1.2.1/go.mod h1:JLbx6lG2kDbNRFnfkgvh4eRJRPX1QCoOIWomwysCBrQ=
+github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/readline v1.5.1 h1:upd/6fQk4src78LMRzh5vItIt361/o4uq553V8B5sGI=
 github.com/chzyer/readline v1.5.1/go.mod h1:Eh+b79XXUwfKfcPLepksvw2tcLE/Ct21YObkaSkeBlk=
+github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/chzyer/test v1.0.0 h1:p3BQDXSxOhOG0P9z6/hGnII4LGiEPOYBhs8asl/fC04=
 github.com/chzyer/test v1.0.0/go.mod h1:2JlltgoNkt4TW/z9V/IzDdFaMTM2JPIi26O1pF38GC8=
 github.com/cpuguy83/go-md2man/v2 v2.0.3 h1:qMCsGGgs+MAzDFyp9LpAe1Lqy/fY/qCovCm0qnXZOBM=
@@ -75,6 +78,8 @@ github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9Y
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
+github.com/manifoldco/promptui v0.9.0 h1:3V4HzJk1TtXW1MTZMP7mdlwbBpIinw3HztaIlYthEiA=
+github.com/manifoldco/promptui v0.9.0/go.mod h1:ka04sppxSGFAtxX0qhlYQjISsg9mR4GWtQEhdbn6Pgg=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
@@ -102,6 +107,7 @@ github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavM
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 golang.org/x/exp v0.0.0-20231214170342-aacd6d4b4611 h1:qCEDpW1G+vcj3Y7Fy52pEM1AWm3abj8WimGYejI3SC4=
 golang.org/x/exp v0.0.0-20231214170342-aacd6d4b4611/go.mod h1:iRJReGqOEeBhDZGkGbynYwcHlctCvnjTYIamk7uXpHI=
+golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/aws/ccapi/ccapi.go
+++ b/internal/aws/ccapi/ccapi.go
@@ -204,11 +204,6 @@ func CreatePatch(props *yaml.Node, priorJson string) (string, error) {
 		return "", err
 	}
 
-	// This is not right. The props might be a single required property,
-	// and the priorModel will have everything, which then renders
-	// a PatchDocument with a bunch of remove operations.
-	// priorModel should be priorJson (from the old template)
-
 	operations, err := jsonpatch.CreatePatch([]byte(priorJson), jsonProps)
 	if err != nil {
 		return "", err

--- a/internal/aws/cfn/mock.go
+++ b/internal/aws/cfn/mock.go
@@ -449,3 +449,7 @@ func DeleteStackSetInstances(stackSetName string, accounts []string, regions []s
 func ListResourceTypes() ([]string, error) {
 	return []string{"AWS::S3::Bucket", "AWS::Lambda::Function"}, nil
 }
+
+func IsCCAPI(t string) (bool, error) {
+	return true, nil
+}

--- a/internal/cmd/cc/cc.go
+++ b/internal/cmd/cc/cc.go
@@ -1,8 +1,6 @@
 package cc
 
 import (
-	"fmt"
-
 	"github.com/aws-cloudformation/rain/cft"
 	"github.com/aws-cloudformation/rain/internal/dc"
 	"github.com/spf13/cobra"
@@ -28,11 +26,6 @@ var Cmd = &cobra.Command{
 	Short: "Interact with templates using Cloud Control API instead of CloudFormation",
 	Long: `You must pass the --experimental (-x) flag to use this command, to acknowledge that it is experimental and likely to be unstable!
 `,
-	Run: run,
-}
-
-func run(cmd *cobra.Command, args []string) {
-	fmt.Println("Usage: cc deploy|rm|state|drift")
 }
 
 func init() {

--- a/internal/cmd/cc/cc.go
+++ b/internal/cmd/cc/cc.go
@@ -2,6 +2,8 @@ package cc
 
 import (
 	"github.com/aws-cloudformation/rain/cft"
+	"github.com/aws-cloudformation/rain/internal/aws/s3"
+	"github.com/aws-cloudformation/rain/internal/config"
 	"github.com/aws-cloudformation/rain/internal/dc"
 	"github.com/spf13/cobra"
 )
@@ -13,7 +15,6 @@ var configFilePath string
 var Experimental bool
 var yes bool
 var ignoreUnknownParams bool
-var downloadState bool
 var unlock string
 
 // Globals (seems bad..? but cumbersome to pass them around)
@@ -26,6 +27,16 @@ var Cmd = &cobra.Command{
 	Short: "Interact with templates using Cloud Control API instead of CloudFormation",
 	Long: `You must pass the --experimental (-x) flag to use this command, to acknowledge that it is experimental and likely to be unstable!
 `,
+}
+
+func addCommonParams(c *cobra.Command) {
+	c.Flags().StringVarP(&config.Profile, "profile", "p", "", "AWS profile name; read from the AWS CLI configuration file")
+	c.Flags().StringVarP(&config.Region, "region", "r", "", "AWS region to use")
+
+	c.Flags().StringVar(&s3.BucketName, "s3-bucket", "", "Name of the S3 bucket that is used to upload assets")
+	c.Flags().StringVar(&s3.BucketKeyPrefix, "s3-prefix", "", "Prefix to add to objects uploaded to S3 bucket")
+	c.Flags().BoolVar(&config.Debug, "debug", false, "Output debugging information")
+	c.Flags().BoolVarP(&Experimental, "experimental", "x", false, "Acknowledge that this is an experimental feature")
 }
 
 func init() {

--- a/internal/cmd/cc/cc.go
+++ b/internal/cmd/cc/cc.go
@@ -32,11 +32,12 @@ var Cmd = &cobra.Command{
 }
 
 func run(cmd *cobra.Command, args []string) {
-	fmt.Println("Usage: cc deploy|rm|state")
+	fmt.Println("Usage: cc deploy|rm|state|drift")
 }
 
 func init() {
 	Cmd.AddCommand(CCDeployCmd)
 	Cmd.AddCommand(CCRmCmd)
 	Cmd.AddCommand(CCStateCmd)
+	Cmd.AddCommand(CCDriftCmd)
 }

--- a/internal/cmd/cc/deploy.go
+++ b/internal/cmd/cc/deploy.go
@@ -87,12 +87,10 @@ func deploy(cmd *cobra.Command, args []string) {
 	// Go through the UI in drift before locking the state file
 
 	// Compare against the current state to see what has changed, if this is an update
-	spinner.Push("Checking state")
 	stateResult, stateError := checkState(name, template, bucketName, "", absPath, unlock)
 	if stateError != nil {
 		panic(stateError)
 	}
-	spinner.Pop()
 
 	config.Debugf("StateFile:\n%v", format.String(stateResult.StateFile,
 		format.Options{JSON: false, Unsorted: false}))

--- a/internal/cmd/cc/deploy.go
+++ b/internal/cmd/cc/deploy.go
@@ -44,7 +44,7 @@ func deploy(cmd *cobra.Command, args []string) {
 
 	// Call RainBucket for side-effects in case we want to force bucket creation
 	// TODO: Use the 'yes' arg instead of true
-	bucketName := s3.RainBucket(true)
+	bucketName := s3.RainBucket(yes)
 
 	// Package template
 	spinner.Push(fmt.Sprintf("Preparing template '%s'", base))

--- a/internal/cmd/cc/deploy.go
+++ b/internal/cmd/cc/deploy.go
@@ -43,6 +43,7 @@ func deploy(cmd *cobra.Command, args []string) {
 	}
 
 	// Call RainBucket for side-effects in case we want to force bucket creation
+	// TODO: Use the 'yes' arg instead of true
 	bucketName := s3.RainBucket(true)
 
 	// Package template

--- a/internal/cmd/cc/deploy.go
+++ b/internal/cmd/cc/deploy.go
@@ -178,15 +178,15 @@ You must pass the --experimental (-x) flag to use this command, to acknowledge t
 }
 
 func init() {
-	CCDeployCmd.Flags().BoolVar(&config.Debug, "debug", false, "Output debugging information")
-	CCDeployCmd.Flags().BoolVarP(&Experimental, "experimental", "x", false, "Acknowledge that this is an experimental feature")
 	CCDeployCmd.Flags().BoolVarP(&yes, "yes", "y", false, "don't ask questions; just deploy")
-	CCDeployCmd.Flags().BoolVarP(&downloadState, "state", "s", false, "Instead of deploying, download the state file")
+	//CCDeployCmd.Flags().BoolVarP(&downloadState, "state", "s", false, "Instead of deploying, download the state file")
 	CCDeployCmd.Flags().StringSliceVar(&tags, "tags", []string{}, "add tags to the stack; use the format key1=value1,key2=value2")
 	CCDeployCmd.Flags().StringSliceVar(&params, "params", []string{}, "set parameter values; use the format key1=value1,key2=value2")
 	CCDeployCmd.Flags().StringVarP(&configFilePath, "config", "c", "", "YAML or JSON file to set tags and parameters")
 	CCDeployCmd.Flags().StringVarP(&unlock, "unlock", "u", "", "Unlock <lockid> and continue")
 	CCDeployCmd.Flags().BoolVarP(&ignoreUnknownParams, "ignore-unknown-params", "", false, "Ignore unknown parameters")
+
+	addCommonParams(CCDeployCmd)
 
 	resMap = make(map[string]*Resource)
 

--- a/internal/cmd/cc/deploy.go
+++ b/internal/cmd/cc/deploy.go
@@ -83,9 +83,6 @@ func deploy(cmd *cobra.Command, args []string) {
 		panic("Unable to deploy this template due to unsupported resources")
 	}
 
-	// TODO - Check for drift somewhere.. maybe in checkState..
-	// Go through the UI in drift before locking the state file
-
 	// Compare against the current state to see what has changed, if this is an update
 	stateResult, stateError := checkState(name, template, bucketName, "", absPath, unlock)
 	if stateError != nil {

--- a/internal/cmd/cc/deployment.go
+++ b/internal/cmd/cc/deployment.go
@@ -63,10 +63,6 @@ func deployResource(resource *Resource) {
 		resolvedNode = resource.Node
 	} else {
 		resolvedNode, err = Resolve(resource)
-		// TODO: Failing due to empty Model on updates
-		// If the dependencies didn't change, they don't get deployed,
-		// so we need to get the Model from the state file.
-		// Or.. query ccapi for the live state?
 		if err != nil {
 			config.Debugf("deployResource resolve failed: %v", err)
 			resource.State = Failed
@@ -93,16 +89,6 @@ func deployResource(resource *Resource) {
 			resource.Model = model
 		}
 	case diff.Update:
-
-		// // First get the current state of the resource
-		// priorModel, err := ccapi.GetResource(resource.Identifier, resource.Type)
-		// if err != nil {
-		// 	config.Debugf("deployResource update get prior failed: %v", err)
-		// 	resource.State = Failed
-		// 	resource.Message = fmt.Sprintf("%v", err)
-		// }
-		//
-		// We would need that at an earlier step for drift detection
 
 		priorJson := resource.PriorJson
 
@@ -387,7 +373,7 @@ func deployResources(resources []*Resource, results *DeploymentResults, g *graph
 	return nil
 }
 
-// deployTemplate deloys the CloudFormation template using the Cloud Control API.
+// deployTemplate deploys the CloudFormation template using the Cloud Control API.
 // A failed deployment will result in DeploymentResults.Succeeded = false.
 // A non-nil error is returned when something unexpected caused a failure
 // not related to actually deploying resources, like an invalid template.
@@ -490,7 +476,6 @@ func DeployTemplate(template cft.Template) (*DeploymentResults, error) {
 			r.PriorJson = priorJson // We need this for ccapi update
 
 			config.Debugf("deployment set r.Model to %v", r.Model)
-			// TODO: This is blank when we update
 
 			if r.Action == diff.Delete {
 				deletes = append(deletes, r)

--- a/internal/cmd/cc/drift.go
+++ b/internal/cmd/cc/drift.go
@@ -190,18 +190,19 @@ func handleDrift(resourceName string, resourceNode *yaml.Node, model *yaml.Node)
 
 	d := diff.CompareMaps(modelMap, liveModelMap)
 
+	resourceSymbol := "🔎 "
 	if d.Mode() == diff.Unchanged {
-		fmt.Println(console.Green(title + "... Ok!"))
+		fmt.Println(console.Green(resourceSymbol + title + "... Ok!"))
 	} else {
-		fmt.Println(console.Red(title + "... Drift detected!"))
+		fmt.Println(console.Red(resourceSymbol + title + "... Drift detected!"))
 		fmt.Println()
 
 		// Show a diff of the live state and stored state
-		fmt.Println("Live state")
-		fmt.Println(colorDiff(d.Format(true)))
+		fmt.Println("    ========== ⚡ Live state ⚡ ==========")
+		fmt.Println("   ", colorDiff(d.Format(true)))
 		reverse := diff.CompareMaps(liveModelMap, modelMap)
-		fmt.Println("Stored state")
-		fmt.Println(colorDiff(reverse.Format(true)))
+		fmt.Println("    ========== 📄 Stored state 📄 ==========")
+		fmt.Println("   ", colorDiff(reverse.Format(true)))
 
 		// Ask the user that they want to do
 
@@ -212,12 +213,12 @@ func handleDrift(resourceName string, resourceNode *yaml.Node, model *yaml.Node)
 		}
 
 		prompt := promptui.Select{
-			Label: "What would you like to do with this resource?",
+			Label: fmt.Sprintf("What would you like to do with %s?", resourceName),
 			Items: selections,
 			Templates: &promptui.SelectTemplates{
 				Label:    "{{ . }}",
 				Active:   "✅ {{ .Text | magenta }}",
-				Inactive: "  {{ .Text }}",
+				Inactive: "   {{ .Text }}",
 				Selected: "✅ {{ .Text | blue }}",
 			},
 		}
@@ -258,7 +259,7 @@ func colorDiff(s string) string {
 			}
 		}
 	}
-	return strings.Join(ret, "\n")
+	return strings.Join(ret, "\n    ")
 }
 
 var CCDriftCmd = &cobra.Command{

--- a/internal/cmd/cc/drift.go
+++ b/internal/cmd/cc/drift.go
@@ -398,6 +398,5 @@ var CCDriftCmd = &cobra.Command{
 }
 
 func init() {
-	CCDriftCmd.Flags().BoolVar(&config.Debug, "debug", false, "Output debugging information")
-	CCDriftCmd.Flags().BoolVarP(&Experimental, "experimental", "x", false, "Acknowledge that this is an experimental feature")
+	addCommonParams(CCDriftCmd)
 }

--- a/internal/cmd/cc/drift.go
+++ b/internal/cmd/cc/drift.go
@@ -50,20 +50,29 @@ func runDrift(cmd *cobra.Command, args []string) {
 		panic(err)
 	}
 
+	spinner.Pop()
+
+	if err := runDriftOnState(name, template, bucketName, key); err != nil {
+		panic(err)
+	}
+}
+
+func runDriftOnState(name string, template cft.Template, bucketName string, key string) error {
+
 	resources, err := template.GetSection(cft.Resources)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	_, err = template.GetSection(cft.State)
 	if err != nil {
-		panic(err)
+		return err
 	}
-
-	spinner.Pop()
 
 	// Display deployment meta-data
 
+	fmt.Println()
+	fmt.Println("Checking for drift on existing deployment")
 	fmt.Println()
 	fmt.Print(console.Blue("Deployment name:  "))
 	fmt.Print(console.Cyan(fmt.Sprintf("%s\n", name)))
@@ -122,7 +131,7 @@ func runDrift(cmd *cobra.Command, args []string) {
 	// Summarize all changes that will be made and ask the user to confirm
 	if !hasChanges {
 		fmt.Println("No changes were made to your infrastructure or to the state file.")
-		return
+		return nil
 	}
 
 	fmt.Println("The following changes will be made:")
@@ -140,7 +149,7 @@ func runDrift(cmd *cobra.Command, args []string) {
 	// Confirm and then actually make the changes
 	if !console.Confirm(true, "Do you wish to continue?") {
 		fmt.Println("Deployment cancelled. No changes have been made to the state file or to live state")
-		return
+		return nil
 	}
 
 	// Set the global template reference for resolving intrinsics
@@ -227,6 +236,7 @@ func runDrift(cmd *cobra.Command, args []string) {
 			fmt.Println("State file updated successfully")
 		}
 	}
+	return nil
 }
 
 type action int

--- a/internal/cmd/cc/drift.go
+++ b/internal/cmd/cc/drift.go
@@ -36,7 +36,7 @@ func runDrift(cmd *cobra.Command, args []string) {
 
 	bucketName := s3.RainBucket(false)
 
-	key := fmt.Sprintf("%v/%v.yaml", STATE_DIR, name) // deployments/name
+	key := getStateFileKey(name)
 
 	obj, err := s3.GetObject(bucketName, key)
 	if err != nil {

--- a/internal/cmd/cc/drift.go
+++ b/internal/cmd/cc/drift.go
@@ -1,0 +1,62 @@
+package cc
+
+import (
+	"fmt"
+
+	"github.com/aws-cloudformation/rain/cft/parse"
+	"github.com/aws-cloudformation/rain/internal/aws/s3"
+	"github.com/aws-cloudformation/rain/internal/config"
+	"github.com/aws-cloudformation/rain/internal/s11n"
+	"github.com/spf13/cobra"
+)
+
+func runDrift(cmd *cobra.Command, args []string) {
+
+	name := args[0]
+
+	if !Experimental {
+		panic("Please add the --experimental arg to use this feature")
+	}
+
+	bucketName := s3.RainBucket(true)
+
+	key := fmt.Sprintf("%v/%v.yaml", STATE_DIR, name) // deployments/name
+
+	obj, err := s3.GetObject(bucketName, key)
+	if err != nil {
+		fmt.Printf("Unable to download state: %v", err)
+		return
+	}
+
+	config.Debugf("State file: %s", obj)
+
+	template, err := parse.String(string(obj))
+	if err != nil {
+		panic(err)
+	}
+
+	_, resources := s11n.GetMapValue(template.Node.Content[0], "Resources")
+	if resources == nil {
+		panic("unable to locate the Resources node")
+	}
+
+	for k, v := range resources.Content {
+		fmt.Printf("%v: %v", k, v)
+	}
+
+}
+
+var CCDriftCmd = &cobra.Command{
+	Use:   "drift <name>",
+	Short: "Compare the state file to the live state of the resources",
+	Long: `When deploying templates with the cc command, a state file is created and stored in the rain assets bucket. This command outputs a diff of that file and the actual state of the resources, according to Cloud Control API.
+`,
+	Args:                  cobra.ExactArgs(1),
+	DisableFlagsInUseLine: true,
+	Run:                   runDrift,
+}
+
+func init() {
+	CCDriftCmd.Flags().BoolVar(&config.Debug, "debug", false, "Output debugging information")
+	CCDriftCmd.Flags().BoolVarP(&Experimental, "experimental", "x", false, "Acknowledge that this is an experimental feature")
+}

--- a/internal/cmd/cc/drift.go
+++ b/internal/cmd/cc/drift.go
@@ -40,7 +40,7 @@ func runDrift(cmd *cobra.Command, args []string) {
 
 	obj, err := s3.GetObject(bucketName, key)
 	if err != nil {
-		panic(fmt.Errorf("Unable to download state: %v", err))
+		panic(fmt.Errorf("unable to download state: %v", err))
 	}
 
 	config.Debugf("State file: %s", obj)

--- a/internal/cmd/cc/drift.go
+++ b/internal/cmd/cc/drift.go
@@ -34,7 +34,7 @@ func runDrift(cmd *cobra.Command, args []string) {
 
 	spinner.Push("Downloading state file")
 
-	bucketName := s3.RainBucket(true)
+	bucketName := s3.RainBucket(false)
 
 	key := fmt.Sprintf("%v/%v.yaml", STATE_DIR, name) // deployments/name
 

--- a/internal/cmd/cc/drift.go
+++ b/internal/cmd/cc/drift.go
@@ -1,13 +1,21 @@
 package cc
 
 import (
+	"encoding/json"
 	"fmt"
+	"strings"
 
+	"github.com/aws-cloudformation/rain/cft"
+	"github.com/aws-cloudformation/rain/cft/diff"
 	"github.com/aws-cloudformation/rain/cft/parse"
+	"github.com/aws-cloudformation/rain/internal/aws/ccapi"
 	"github.com/aws-cloudformation/rain/internal/aws/s3"
 	"github.com/aws-cloudformation/rain/internal/config"
+	"github.com/aws-cloudformation/rain/internal/console"
+	"github.com/aws-cloudformation/rain/internal/console/spinner"
 	"github.com/aws-cloudformation/rain/internal/s11n"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 func runDrift(cmd *cobra.Command, args []string) {
@@ -18,14 +26,15 @@ func runDrift(cmd *cobra.Command, args []string) {
 		panic("Please add the --experimental arg to use this feature")
 	}
 
+	spinner.Push("Downloading state file")
+
 	bucketName := s3.RainBucket(true)
 
 	key := fmt.Sprintf("%v/%v.yaml", STATE_DIR, name) // deployments/name
 
 	obj, err := s3.GetObject(bucketName, key)
 	if err != nil {
-		fmt.Printf("Unable to download state: %v", err)
-		return
+		panic(fmt.Errorf("Unable to download state: %v", err))
 	}
 
 	config.Debugf("State file: %s", obj)
@@ -35,21 +44,161 @@ func runDrift(cmd *cobra.Command, args []string) {
 		panic(err)
 	}
 
-	_, resources := s11n.GetMapValue(template.Node.Content[0], "Resources")
-	if resources == nil {
-		panic("unable to locate the Resources node")
+	resources, err := template.GetSection(cft.Resources)
+	if err != nil {
+		panic(err)
 	}
 
-	for k, v := range resources.Content {
-		fmt.Printf("%v: %v", k, v)
+	_, err = template.GetSection(cft.State)
+	if err != nil {
+		panic(err)
 	}
 
+	spinner.Pop()
+
+	// Display deployment meta-data
+
+	fmt.Println()
+	fmt.Print(console.Blue("Deployment name:  "))
+	fmt.Print(console.Cyan(fmt.Sprintf("%s\n", name)))
+
+	fmt.Print(console.Blue("State file:       "))
+	fmt.Print(console.Cyan(fmt.Sprintf("s3://%s/%s\n", bucketName, key)))
+
+	localPath, err := template.GetNode(cft.State, "FilePath")
+	if err != nil {
+		panic(err)
+	}
+	fmt.Print(console.Blue("Local path:       "))
+	fmt.Print(console.Cyan(fmt.Sprintf("%s\n", localPath.Value)))
+
+	lastWrite, err := template.GetNode(cft.State, "LastWriteTime")
+	if err != nil {
+		panic(err)
+	}
+	fmt.Print(console.Blue("Last write time:  "))
+	fmt.Print(console.Cyan(fmt.Sprintf("%s\n", lastWrite.Value)))
+
+	resourceModels, err := template.GetNode(cft.State, "ResourceModels")
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println()
+
+	// Query each resource and stop to ask how to handle drift after each one
+	for i := 0; i < len(resources.Content); i += 2 {
+		resourceName := resources.Content[i].Value
+		resourceNode := resources.Content[i+1]
+		_, resourceModel := s11n.GetMapValue(resourceModels, resourceName)
+		if resourceModel == nil {
+			panic(fmt.Errorf("expected %s to have a ResourceModel", resourceName))
+		}
+		err := handleDrift(resourceName, resourceNode, resourceModel)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+}
+
+func handleDrift(resourceName string, resourceNode *yaml.Node, model *yaml.Node) error {
+
+	_, t := s11n.GetMapValue(resourceNode, "Type")
+	if t == nil {
+		return fmt.Errorf("resource %s expected to have Type", resourceName)
+	}
+	_, id := s11n.GetMapValue(model, "Identifier")
+	if id == nil {
+		return fmt.Errorf("resource model %s expected to have Identifier", resourceName)
+	}
+	title := fmt.Sprintf("%s (%s %s)", resourceName, t.Value, id.Value)
+
+	spinner.Push(fmt.Sprintf("Querying CCAPI: %s", title))
+
+	liveModelString, err := ccapi.GetResource(id.Value, t.Value)
+	if err != nil {
+		return err
+	}
+	spinner.Pop()
+
+	_, stateModel := s11n.GetMapValue(model, "Model")
+	if stateModel == nil {
+		return fmt.Errorf("expected State %s to have Model", resourceName)
+	}
+
+	//modelString, _ := json.MarshalIndent(format.Jsonise(stateModel), "", "    ")
+
+	var liveModelMap map[string]any
+	err = json.Unmarshal([]byte(liveModelString), &liveModelMap)
+	if err != nil {
+		return err
+	}
+
+	var modelMap map[string]any
+	err = stateModel.Decode(&modelMap)
+	if err != nil {
+		panic(err)
+	}
+
+	d := diff.CompareMaps(modelMap, liveModelMap)
+
+	if d.Mode() == diff.Unchanged {
+		fmt.Println(console.Green(title + "... Ok!"))
+	} else {
+		fmt.Println(console.Red(title + "... Drift detected!"))
+		fmt.Println()
+		fmt.Println("Live state")
+		fmt.Println(colorDiff(d.Format(true)))
+		reverse := diff.CompareMaps(liveModelMap, modelMap)
+		fmt.Println("Stored state")
+		fmt.Println(colorDiff(reverse.Format(true)))
+	}
+
+	// TODO
+	//
+	// What would you like to do with this resource?
+	//
+	// 1. Fix the live state so it matches the state file
+	// 2. Apply the live state to the state file
+	// 3. Do nothing
+	//
+	// [Continue asking about each resource, remembering answers]
+	// [Confirm the changes that will be made using the normal deployment flow]
+
+	fmt.Println()
+	return nil
+}
+
+// colorDiff hacks the diff output to colorize it
+func colorDiff(s string) string {
+	lines := strings.Split(s, "\n")
+	f := "%s "
+	//changed := []string{diff.Added, diff.Removed, diff.Changed, diff.Involved}
+	unchanged := fmt.Sprintf(f, diff.Unchanged)
+	ret := make([]string, 0)
+	for _, line := range lines {
+		// Lines look like these:
+		// (=) QueryDefinitionId: 0abf4544-b551-4b79-93d0-6f7f294cdbaa
+		// (>) QueryString: fields @message, @timestamp
+		tokens := strings.SplitAfterN(line, " ", 2)
+		if len(tokens) != 2 {
+			ret = append(ret, console.Yellow(line)) // Shouldn't happen
+		} else {
+			if tokens[0] == unchanged {
+				ret = append(ret, console.Green(tokens[1]))
+			} else {
+				ret = append(ret, console.Red(tokens[1]))
+			}
+		}
+	}
+	return strings.Join(ret, "\n")
 }
 
 var CCDriftCmd = &cobra.Command{
 	Use:   "drift <name>",
 	Short: "Compare the state file to the live state of the resources",
-	Long: `When deploying templates with the cc command, a state file is created and stored in the rain assets bucket. This command outputs a diff of that file and the actual state of the resources, according to Cloud Control API.
+	Long: `When deploying templates with the cc command, a state file is created and stored in the rain assets bucket. This command outputs a diff of that file and the actual state of the resources, according to Cloud Control API. You can then apply the changes by changing the live state, or by modifying the state file.
 `,
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,

--- a/internal/cmd/cc/drift.go
+++ b/internal/cmd/cc/drift.go
@@ -315,12 +315,14 @@ func handleDrift(resourceName string, resourceNode *yaml.Node, model *yaml.Node)
 	checkIcon := "✅"
 	resourceIcon := "🔎 "
 
-	if console.NoColour {
-		liveIcon = "*"
-		storedIcon = "."
-		checkIcon = "> "
-		resourceIcon = "-> "
-	}
+	// Is there any reason not to show the icons?
+	//
+	// if console.NoColour {
+	// 	liveIcon = "*"
+	// 	storedIcon = "."
+	// 	checkIcon = "> "
+	// 	resourceIcon = "-> "
+	// }
 
 	if d.Mode() == diff.Unchanged {
 		fmt.Println(console.Green(resourceIcon + title + "... Ok!"))

--- a/internal/cmd/cc/rm.go
+++ b/internal/cmd/cc/rm.go
@@ -132,7 +132,6 @@ var CCRmCmd = &cobra.Command{
 }
 
 func init() {
-	CCRmCmd.Flags().BoolVar(&config.Debug, "debug", false, "Output debugging information")
-	CCRmCmd.Flags().BoolVarP(&Experimental, "experimental", "x", false, "Acknowledge that this is an experimental feature")
 	CCRmCmd.Flags().BoolVarP(&yes, "yes", "y", false, "don't ask questions; just delete")
+	addCommonParams(CCRmCmd)
 }

--- a/internal/cmd/cc/rm.go
+++ b/internal/cmd/cc/rm.go
@@ -36,7 +36,7 @@ var CCRmCmd = &cobra.Command{
 		var state cft.Template
 
 		// Call RainBucket for side-effects in case we want to force bucket creation
-		bucketName := s3.RainBucket(true)
+		bucketName := s3.RainBucket(yes)
 
 		obj, err := s3.GetObject(bucketName, key)
 		if err != nil {

--- a/internal/cmd/cc/rm.go
+++ b/internal/cmd/cc/rm.go
@@ -32,7 +32,7 @@ var CCRmCmd = &cobra.Command{
 		}
 
 		spinner.Push("Fetching deployment status")
-		key := fmt.Sprintf("%v/%v.yaml", STATE_DIR, name) // deployments/name
+		key := getStateFileKey(name)
 		var state cft.Template
 
 		// Call RainBucket for side-effects in case we want to force bucket creation

--- a/internal/cmd/cc/state.go
+++ b/internal/cmd/cc/state.go
@@ -257,7 +257,7 @@ func runState(cmd *cobra.Command, args []string) {
 	}
 
 	// Call RainBucket for side-effects in case we want to force bucket creation
-	bucketName := s3.RainBucket(true)
+	bucketName := s3.RainBucket(false)
 
 	key := fmt.Sprintf("%v/%v.yaml", STATE_DIR, name) // deployments/name
 

--- a/internal/cmd/cc/state.go
+++ b/internal/cmd/cc/state.go
@@ -281,6 +281,5 @@ var CCStateCmd = &cobra.Command{
 }
 
 func init() {
-	CCStateCmd.Flags().BoolVar(&config.Debug, "debug", false, "Output debugging information")
-	CCStateCmd.Flags().BoolVarP(&Experimental, "experimental", "x", false, "Acknowledge that this is an experimental feature")
+	addCommonParams(CCStateCmd)
 }

--- a/internal/cmd/cc/state.go
+++ b/internal/cmd/cc/state.go
@@ -153,6 +153,8 @@ func checkState(
 			}
 		}
 
+		// TODO - This would be the place to stop and check drift before deployment
+
 		// We are safe to proceed with an update.
 		// Write a new lock back to the state file stored in S3.
 		// If we're unlocking to continue a failed deployment, leave it

--- a/internal/console/colours.go
+++ b/internal/console/colours.go
@@ -53,3 +53,6 @@ var Bold = wrap(color.New(color.Bold))
 
 // Plain returns the input as a string of normal-coloured text if the console supports colours
 var Plain = wrap(color.New(color.Normal))
+
+// Magenta returns the input as a string of magenta-coloured text if the console supports colours
+var Magenta = wrap(color.New(color.Magenta))

--- a/internal/console/console.go
+++ b/internal/console/console.go
@@ -122,3 +122,8 @@ func Confirm(defaultYes bool, prompt string) bool {
 
 	return false
 }
+
+// Errorf prints a red message to standard out
+func Errorf(f string, args ...any) {
+	fmt.Println(Red(fmt.Sprintf(f, args...)))
+}


### PR DESCRIPTION
This only applies to templates deployed with `rain cc deploy`, an experimental feature that bypasses CloudFormation stacks and deploys resources directly with Cloud Control API. We might also consider building something like this for normal CloudFormation deployments.

As sample of the UI for detecting drift in a resource:

<img width="1065" alt="Screenshot 2024-02-01 at 2 48 49 PM" src="https://github.com/aws-cloudformation/rain/assets/663183/5f7cb552-198a-431c-a694-0810abe6b83a">

@hariprakash-j, @khmoryz, @null93, @iainelder, would love some feedback on this. (Still working on approvals so I can add you as actual reviewers)