### PR TITLE
Implement a "User Initiated" filter option for the rain logs command

### DIFF
--- a/internal/cmd/logs/logs.go
+++ b/internal/cmd/logs/logs.go
@@ -13,6 +13,7 @@ var allLogs = false
 var chart = false
 var logsLength uint
 var logsDays uint
+var sinceUserInitiated = false
 
 // Cmd is the logs command's entrypoint
 var Cmd = &cobra.Command{
@@ -63,4 +64,5 @@ func init() {
 	Cmd.Flags().BoolVar(&config.Debug, "debug", false, "Output debugging information")
 	Cmd.Flags().UintVarP(&logsLength, "length", "l", 0, "Number of logs to display")
 	Cmd.Flags().UintVarP(&logsDays, "days", "d", 0, "Age of the logs to display in days")
+	Cmd.Flags().BoolVarP(&sinceUserInitiated, "since-user-initiated", "s", false, "Only show logs since the last 'User Initiated' event")
 }

--- a/internal/cmd/logs/logs_test.go
+++ b/internal/cmd/logs/logs_test.go
@@ -26,10 +26,11 @@ func Example_logs_help() {
 	//   logs, log
 	//
 	// Flags:
-	//   -a, --all           include uninteresting logs
-	//   -c, --chart         Output a gantt chart of the most recent action as an html file
-	//   -d, --days uint     Age of the logs to display in days
-	//       --debug         Output debugging information
-	//   -h, --help          help for logs
-	//   -l, --length uint   Number of logs to display
+	//   -a, --all                    include uninteresting logs
+	//   -c, --chart                  Output a gantt chart of the most recent action as an html file
+	//   -d, --days uint              Age of the logs to display in days
+	//       --debug                  Output debugging information
+	//   -h, --help                   help for logs
+	//   -l, --length uint            Number of logs to display
+	//   -s, --since-user-initiated   Only show logs since the last 'User Initiated' event
 }

--- a/internal/cmd/logs/util.go
+++ b/internal/cmd/logs/util.go
@@ -150,6 +150,19 @@ func getLogs(stackName, resourceName string) (events, error) {
 		logs[i], logs[j] = logs[j], logs[i]
 	}
 
+	// Filter out logs since last user initiated event
+	if sinceUserInitiated {
+		newLogs = make([]types.StackEvent, 0)
+		for _, log := range logs {
+			isLatestUserInitiated := log.ResourceStatusReason != nil && *log.ResourceStatusReason == "User Initiated"
+			newLogs = append(newLogs, log)
+			if isLatestUserInitiated {
+				break
+			}
+		}
+		logs = newLogs
+	}
+
 	spinner.Pop()
 
 	return logs, nil


### PR DESCRIPTION
*Issue #, if available:*
#236

*Description of changes:*
Add -s / --since-user-initiated flag for only showing logs since the last 'User Initiated' event

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
