### PR TITLE
Use regional endpoints for large template uploads to S3

### DIFF
--- a/internal/aws/cfn/cfn.go
+++ b/internal/aws/cfn/cfn.go
@@ -78,7 +78,7 @@ func checkTemplate(template cft.Template) (string, error) {
 		if strings.HasPrefix(region, "cn-") {
 			return fmt.Sprintf("https://%s.s3.%s.amazonaws.com.cn/%s", bucket, region, key), err
 		} else {
-			return fmt.Sprintf("https://%s.s3.amazonaws.com/%s", bucket, key), err
+			return fmt.Sprintf("https://%s.s3.%s.amazonaws.com/%s", bucket, region, key), err
 		}
 	}
 


### PR DESCRIPTION

*Issue #538 

*Description of changes: Switch to using regional S3 endpoints (rather than the legacy global endpoint) when uploading large templates to S3 prior to deployment. This should better support US Gov regions, as well as any commercial region created after March 20, 2019 (per https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#VirtualHostingBackwardsCompatibility)

The change was successfully tested locally in us-east-1 and us-gov-west-1


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
