### PR TITLE
Make including nested stacks in a change set optional

### DIFF
--- a/internal/aws/cfn/cfn.go
+++ b/internal/aws/cfn/cfn.go
@@ -296,8 +296,6 @@ type ChangeSetContext struct {
 }
 
 // CreateChangeSet creates a changeset
-//
-// changeSetName is optional, if "" is passed in,
 func CreateChangeSet(ctx *ChangeSetContext) (string, error) {
 
 	template := ctx.Template
@@ -558,8 +556,6 @@ func GetTypePermissions(name string, handlerVerb string) ([]string, error) {
 	           "s3:PutBucketTagging",
 
 	*/
-
-	//config.Debugf("GetTypePermissions result: %v", result)
 
 	retval := make([]string, 0)
 

--- a/internal/aws/cfn/cfn.go
+++ b/internal/aws/cfn/cfn.go
@@ -281,16 +281,31 @@ func GetStackEvents(stackName string) ([]types.StackEvent, error) {
 	return events, nil
 }
 
+type ChangeSetContext struct {
+	Template  cft.Template
+	Params    []types.Parameter
+	Tags      map[string]string
+	StackName string
+
+	// ChangeSetName is optional, if "" is set, the name will be the stack name plus a timestamp
+	ChangeSetName string
+	RoleArn       string
+
+	// Whether or not to include nested stacks in the change set
+	IncludeNested bool
+}
+
 // CreateChangeSet creates a changeset
 //
-// changeSetName is optional, if "" is passed in, the name will be the stack name plus a timestamp
-func CreateChangeSet(
-	template cft.Template,
-	params []types.Parameter,
-	tags map[string]string,
-	stackName string,
-	changeSetName string,
-	roleArn string) (string, error) {
+// changeSetName is optional, if "" is passed in,
+func CreateChangeSet(ctx *ChangeSetContext) (string, error) {
+
+	template := ctx.Template
+	params := ctx.Params
+	tags := ctx.Tags
+	stackName := ctx.StackName
+	changeSetName := ctx.ChangeSetName
+	roleArn := ctx.RoleArn
 
 	templateBody, err := checkTemplate(template)
 	if err != nil {
@@ -317,7 +332,7 @@ func CreateChangeSet(
 		ChangeSetName:       ptr.String(changeSetName),
 		StackName:           ptr.String(stackName),
 		Tags:                dc.MakeTags(tags),
-		IncludeNestedStacks: ptr.Bool(true),
+		IncludeNestedStacks: ptr.Bool(ctx.IncludeNested),
 		Parameters:          params,
 		Capabilities: []types.Capability{
 			"CAPABILITY_NAMED_IAM",

--- a/internal/cmd/deploy/deploy.go
+++ b/internal/cmd/deploy/deploy.go
@@ -35,6 +35,7 @@ var ignoreUnknownParams bool
 var noexec bool
 var changeset bool
 var experimental bool
+var includeNested bool
 
 // Cmd is the deploy command's entrypoint
 var Cmd = &cobra.Command{
@@ -160,7 +161,16 @@ To list and delete changesets, use the ls and rm commands.
 			// Create change set
 			spinner.Push("Creating change set")
 			var createErr error
-			changeSetName, createErr = cfn.CreateChangeSet(template, dc.Params, dc.Tags, stackName, changeSetName, roleArn)
+			ctx := cfn.ChangeSetContext{
+				Template:      template,
+				Params:        dc.Params,
+				Tags:          dc.Tags,
+				StackName:     stackName,
+				ChangeSetName: changeSetName,
+				RoleArn:       roleArn,
+				IncludeNested: includeNested,
+			}
+			changeSetName, createErr = cfn.CreateChangeSet(&ctx)
 			if createErr != nil {
 				if changeSetHasNoChanges(createErr.Error()) {
 					spinner.Pop()
@@ -320,4 +330,5 @@ func init() {
 	Cmd.Flags().BoolVar(&changeset, "changeset", false, "execute the changeset, rain deploy --changeset <stackName> <changeSetName>")
 	Cmd.Flags().StringVar(&format.NodeStyle, "node-style", "original", format.NodeStyleDocs)
 	Cmd.Flags().BoolVar(&experimental, "experimental", false, "Acknowledge that you want to deploy with an experimental feature")
+	Cmd.Flags().BoolVar(&includeNested, "nested-change-set", true, "Whether or not to include nested stacks in the change set")
 }

--- a/internal/cmd/deploy/deploy.go
+++ b/internal/cmd/deploy/deploy.go
@@ -14,7 +14,6 @@ import (
 	"github.com/aws-cloudformation/rain/internal/console"
 	"github.com/aws-cloudformation/rain/internal/console/spinner"
 	"github.com/aws-cloudformation/rain/internal/dc"
-	"github.com/aws-cloudformation/rain/internal/node"
 	"github.com/aws-cloudformation/rain/internal/s11n"
 	"github.com/aws-cloudformation/rain/internal/ui"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
@@ -170,6 +169,7 @@ To list and delete changesets, use the ls and rm commands.
 				RoleArn:       roleArn,
 				IncludeNested: includeNested,
 			}
+			config.Debugf("ChangeSetContext: %+v", ctx)
 			changeSetName, createErr = cfn.CreateChangeSet(&ctx)
 			if createErr != nil {
 				if changeSetHasNoChanges(createErr.Error()) {
@@ -291,7 +291,6 @@ func changeSetHasNoChanges(msg string) bool {
 // hasRainMetadata returns true if the template has a resource
 // with a Metadata section with a Rain node
 func HasRainMetadata(template cft.Template) bool {
-	config.Debugf("template: %v", node.ToSJson(template.Node))
 	if template.Node.Content[0].Kind == yaml.DocumentNode {
 		template.Node = template.Node.Content[0]
 	}


### PR DESCRIPTION
Fixes #526. Add `--nested-change-set=false` to the `deploy` command.