### PR TITLE
Remove confirmation prompt for deploy --no-exec

### DIFF
--- a/internal/cmd/deploy/deploy.go
+++ b/internal/cmd/deploy/deploy.go
@@ -182,6 +182,19 @@ To list and delete changesets, use the ls and rm commands.
 			}
 			spinner.Pop()
 
+			// Display changeset and exit
+			if noexec {
+				spinner.Push("Formatting change set")
+				status := formatChangeSet(stackName, changeSetName)
+				spinner.Pop()
+
+				fmt.Println("Changeset contains the following changes:")
+				fmt.Println(status)
+
+				fmt.Println("changeset created but not executed:", changeSetName)
+				return
+			}
+
 			// Confirm changes
 			if !yes {
 				spinner.Push("Formatting change set")
@@ -208,10 +221,6 @@ To list and delete changesets, use the ls and rm commands.
 				}
 			}
 
-			if noexec {
-				fmt.Println("changeset created but not executed:", changeSetName)
-				return
-			}
 		}
 
 		// Deploy!


### PR DESCRIPTION
**Issue #:** #580 

**Description of changes:** Change wording of output when running `deploy --noexec` and remove confirmation prompt


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
