### PR TITLE
Fix s3bucket option for stackset deploy

### DIFF
--- a/internal/cmd/rain/rain.go
+++ b/internal/cmd/rain/rain.go
@@ -91,7 +91,7 @@ func init() {
 	addCommand(stackGroup, true, false, ls.Cmd)
 	addCommand(stackGroup, true, false, rm.Cmd)
 	addCommand(stackGroup, true, false, watch.Cmd)
-	addCommand(stackGroup, true, true, stackset.StackSetCmd)
+	addCommand(stackGroup, true, false, stackset.StackSetCmd)
 
 	// Template commands
 	addCommand(templateGroup, true, true, bootstrap.Cmd)

--- a/internal/cmd/stackset/stackset.go
+++ b/internal/cmd/stackset/stackset.go
@@ -1,6 +1,7 @@
 package stackset
 
 import (
+	"github.com/aws-cloudformation/rain/internal/aws/s3"
 	"github.com/aws-cloudformation/rain/internal/config"
 	"github.com/aws-cloudformation/rain/internal/console"
 	"github.com/spf13/cobra"
@@ -33,10 +34,15 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 var delegatedAdmin bool
 
 // addCommand adds a command to the root command.
-func addCommand(profileOptions bool, c *cobra.Command) {
+func addCommand(profileOptions bool, bucketOptions bool, c *cobra.Command) {
 	if profileOptions {
 		c.Flags().StringVarP(&config.Profile, "profile", "p", "", "AWS profile name; read from the AWS CLI configuration file")
 		c.Flags().StringVarP(&config.Region, "region", "r", "", "AWS region to use")
+	}
+	if bucketOptions {
+		c.Flags().StringVar(&s3.BucketName, "s3-bucket", "", "Name of the S3 bucket that is used to upload assets")
+		c.Flags().StringVar(&s3.BucketKeyPrefix, "s3-prefix", "", "Prefix to add to objects uploaded to S3 bucket")
+		c.Flags().StringVar(&s3.ExpectedBucketOwner, "s3-owner", "", "The account where S3 assets are stored")
 	}
 
 	c.Flags().BoolVar(&delegatedAdmin, "admin", false, "Use delegated admin permissions")
@@ -51,9 +57,9 @@ var StackSetCmd = &cobra.Command{
 }
 
 func init() {
-	addCommand(true, LsCmd)
-	addCommand(true, DeployCmd)
-	addCommand(true, RmCmd)
+	addCommand(true, false, LsCmd)
+	addCommand(true, true, DeployCmd)
+	addCommand(true, false, RmCmd)
 
 	oldUsageFunc := StackSetCmd.UsageFunc()
 	StackSetCmd.SetUsageFunc(func(c *cobra.Command) error {


### PR DESCRIPTION
*Issue #, if available:* #528

*Description of changes:*
While using the feature requested in the mentioned ticket, rain didn't accept the `--s3-bucket` on `rain stackset deploy`. It only worked for `rain stackset` the subcommand 'root'. 

After investigating the original change and comparing how the s3 commands are made available in `rain cc`, `rain deploy` and `rm` I offer this MR that allows the use of the s3-commands with `rain stackset deploy`. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
