### PR TITLE
docs: add markdown formatting to example text and link to example file

### DIFF
--- a/internal/cmd/stackset/stackset_deploy.go
+++ b/internal/cmd/stackset/stackset_deploy.go
@@ -52,9 +52,10 @@ Rain will attempt to create an S3 bucket to store artifacts that it packages and
 The bucket's name will be of the format rain-artifacts-<AWS account id>-<AWS region>.
 
 The config flags can be used to set accounts, regions to operate and tags with parameters to use.
-Configuration file with extended options can be provided along with '--config' flag in YAML or JSON format (see example file for details).
+Configuration file with extended options can be provided along with '--config' flag in YAML or JSON format (see [example file](https://github.com/aws-cloudformation/rain/blob/main/test/samples/test-config.yaml) for details).
 
 YAML:
+` + "```" + `
 Parameters:
 	Name: Value
 Tags:
@@ -68,9 +69,10 @@ StackSetInstances:
 	regions:
 		- us-east-1
 		- us-east-2
-...
+	...
+` + "```" + `
 
-Account(s) and region(s) provided as flags OVERRIDE values from configuration files. Tags and parameters from the configuration file are MERGED with CLI flag values. 
+Account(s) and region(s) provided as flags OVERRIDE values from configuration files. Tags and parameters from the configuration file are MERGED with CLI flag values.
 `,
 	Args:                  cobra.RangeArgs(1, 2),
 	DisableFlagsInUseLine: false,


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*
Documentation change:
- Put the example YAML mentioned in `rain stackset deploy` in a Markdown code block, so new lines and syntax is preserved after generating into Markdown. 
- Add link to the example configuration file located in the test/samples folder.

Adding the code block syntax affects the help message on the CLI slightly. However, I do understand if the link is too much. Just let me know if any changes are desired.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
