### PR TITLE
Added uncdk to fmt command

### DIFF
--- a/cft/cft.go
+++ b/cft/cft.go
@@ -97,7 +97,6 @@ func (t Template) GetParameter(name string) (*yaml.Node, error) {
 func (t Template) GetNode(section Section, name string) (*yaml.Node, error) {
 	_, resMap, _ := s11n.GetMapValue(t.Node.Content[0], string(section))
 	if resMap == nil {
-		config.Debugf("GetNode t.Node: %s", node.ToSJson(t.Node))
 		return nil, fmt.Errorf("unable to locate the %s node", section)
 	}
 	// TODO: Some Sections are not Maps
@@ -144,7 +143,6 @@ func (t Template) GetSection(section Section) (*yaml.Node, error) {
 	m := t.Node.Content[0]
 	_, s, _ := s11n.GetMapValue(m, string(section))
 	if s == nil {
-		config.Debugf("GetSection t.Node: %s", node.ToSJson(t.Node))
 		return nil, fmt.Errorf("unable to locate the %s node", section)
 	}
 	return s, nil
@@ -202,4 +200,27 @@ func (t Template) GetResourcesOfType(typeName string) []*Resource {
 		}
 	}
 	return retval
+}
+
+// RemoveEmptySections removes sections from the template that have no content
+func (t Template) RemoveEmptySections() {
+	if t.Node == nil {
+		config.Debugf("t.Node is nil")
+		return
+	}
+	m := t.Node.Content[0]
+	sectionsToRemove := make([]string, 0)
+	for i := 0; i < len(m.Content); i++ {
+		if i%2 != 0 {
+			continue
+		}
+		name := m.Content[i].Value
+		node := m.Content[i+1]
+		if len(node.Content) == 0 {
+			sectionsToRemove = append(sectionsToRemove, name)
+		}
+	}
+	for _, name := range sectionsToRemove {
+		node.RemoveFromMap(m, name)
+	}
 }

--- a/cft/format/json.go
+++ b/cft/format/json.go
@@ -3,11 +3,9 @@ package format
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"strings"
 
 	"github.com/aws-cloudformation/rain/cft/parse"
-	"github.com/aws-cloudformation/rain/internal/config"
 	"gopkg.in/yaml.v3"
 )
 
@@ -33,8 +31,6 @@ func handleScalar(node *yaml.Node) interface{} {
 	if err != nil {
 		panic(err)
 	}
-
-	config.Debugf("intermediate: %v", string(intermediate))
 
 	var out interface{}
 	err = yaml.Unmarshal(intermediate, &out)
@@ -72,8 +68,6 @@ func Jsonise(node *yaml.Node) interface{} {
 
 func convertToJSON(in string) string {
 
-	config.Debugf("convertToJson: %v", in)
-
 	var d yaml.Node
 
 	err := yaml.Unmarshal([]byte(in), &d)
@@ -104,14 +98,11 @@ func PrettyPrint(i interface{}) string {
 
 // ToJson overrides the default behavior of json.Marshal to leave < > alone
 func ToJson(i interface{}, indent string) ([]byte, error) {
-	si := fmt.Sprintf("%#v", i)
-	config.Debugf("ToJson(%s)", si)
 	buf := &bytes.Buffer{}
 	enc := json.NewEncoder(buf)
 	enc.SetEscapeHTML(false)
 	enc.SetIndent("", indent)
 	err := enc.Encode(i)
 	retval := bytes.TrimRight(buf.Bytes(), "\n")
-	config.Debugf("ToJson retval: %s", retval)
 	return retval, err
 }

--- a/cft/format/uncdk.go
+++ b/cft/format/uncdk.go
@@ -133,7 +133,6 @@ func replaceNames(t cft.Template, oldName, newName string) {
 		yamlNode := n.GetYamlNode()
 		if yamlNode.Kind == yaml.ScalarNode {
 			if yamlNode.Value == oldName {
-				config.Debugf("replacing %s with %s", oldName, newName)
 				yamlNode.Value = newName
 			}
 		}

--- a/cft/format/uncdk.go
+++ b/cft/format/uncdk.go
@@ -1,0 +1,143 @@
+package format
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws-cloudformation/rain/cft"
+	"github.com/aws-cloudformation/rain/cft/visitor"
+	"github.com/aws-cloudformation/rain/internal/config"
+	"github.com/aws-cloudformation/rain/internal/node"
+	"github.com/aws-cloudformation/rain/internal/s11n"
+	"gopkg.in/yaml.v3"
+)
+
+func UnCDK(t cft.Template) error {
+
+	// Remove these nodes:
+	//
+	// Resources:
+	//   CDKMetadata:
+	//   {*}:
+	//     Metadata:
+	//       aws:cdk:path:
+	// Conditions:
+	//   CDKMetadataAvailable:
+	// Parameters:
+	//   BootstrapVersion:
+	// Rules:
+	//   CheckBootstrapVersion:
+
+	removals := make(map[string][]string)
+	removals[string(cft.Resources)] = []string{"CDKMetadata"}
+	removals[string(cft.Conditions)] = []string{"CDKMetadataAvailable"}
+	removals[string(cft.Parameters)] = []string{"BootstrapVersion"}
+	removals[string(cft.Rules)] = []string{"CheckBootstrapVersion"}
+
+	for k, v := range removals {
+		section, err := t.GetSection(cft.Section(k))
+		if err != nil {
+			continue // Section not found
+		}
+		for _, name := range v {
+			n := s11n.GetMap(section, name)
+			if n != nil {
+				node.RemoveFromMap(section, name)
+			}
+		}
+	}
+
+	// Iterate through all the resources to remove cdk metadata,
+	// And fix the logical ids so they are easier to read
+
+	resources, err := t.GetSection(cft.Resources)
+	if err != nil {
+		return err
+	}
+
+	// Store the resource logical id node each time we see a repeated name
+	// Start without a number, for example "Bucket"
+	// If we see another one, fix the first one to be "Bucket0"
+	allNames := make(map[string][]*yaml.Node)
+
+	for i := 0; i < len(resources.Content); i += 1 {
+		if i%2 != 0 {
+			continue
+		}
+		logicalId := resources.Content[i].Value
+		resource := resources.Content[i+1]
+
+		// Simplify the logical id
+		_, typ, _ := s11n.GetMapValue(resource, "Type")
+		if typ == nil {
+			return fmt.Errorf("expected %s to have Type", logicalId)
+		}
+		tokens := strings.Split(typ.Value, "::")
+		if len(tokens) < 3 {
+			// TODO ::Module would break here
+			config.Debugf("unexpected %s Type is %s", logicalId, typ.Value)
+		} else {
+			oldName := resources.Content[i].Value
+			newName := tokens[2]
+			if nameNodes, ok := allNames[newName]; ok {
+				// We've seen this one before
+				nameNodes = append(nameNodes, resources.Content[i])
+				for nodeIdx, node := range nameNodes {
+					sequential := fmt.Sprintf("%s%d", newName, nodeIdx)
+					priorValue := node.Value
+					node.Value = sequential
+					replaceNames(t, priorValue, sequential)
+				}
+			} else {
+				// We haven't seen this name yet
+				resources.Content[i].Value = newName
+				allNames[newName] = make([]*yaml.Node, 0)
+				allNames[newName] = append(allNames[newName], resources.Content[i])
+				replaceNames(t, oldName, newName)
+			}
+		}
+
+		// Remove the cdk path
+		_, metadata, _ := s11n.GetMapValue(resource, string(cft.Metadata))
+		if metadata != nil {
+			cdkPath := "aws:cdk:path"
+			found := false
+			for m := 0; m < len(metadata.Content); m += 2 {
+				if metadata.Content[m].Value == cdkPath {
+					found = true
+					break
+				}
+			}
+			if found {
+				err := node.RemoveFromMap(metadata, cdkPath)
+				if err != nil {
+					return err // This should not happen
+				}
+			}
+		}
+		// If the resource Metadata node is empty, remove it
+		if len(metadata.Content) == 0 {
+			node.RemoveFromMap(resource, string(cft.Metadata))
+		}
+	}
+
+	// Remove any empty sections
+	t.RemoveEmptySections()
+
+	return nil // TODO
+
+}
+
+func replaceNames(t cft.Template, oldName, newName string) {
+	vf := func(n *visitor.Visitor) {
+		yamlNode := n.GetYamlNode()
+		if yamlNode.Kind == yaml.ScalarNode {
+			if yamlNode.Value == oldName {
+				config.Debugf("replacing %s with %s", oldName, newName)
+				yamlNode.Value = newName
+			}
+		}
+	}
+	visitor := visitor.NewVisitor(t.Node)
+	visitor.Visit(vf)
+}

--- a/cft/format/uncdk.go
+++ b/cft/format/uncdk.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws-cloudformation/rain/cft"
 	"github.com/aws-cloudformation/rain/cft/visitor"
-	"github.com/aws-cloudformation/rain/internal/config"
 	"github.com/aws-cloudformation/rain/internal/node"
 	"github.com/aws-cloudformation/rain/internal/s11n"
 	"gopkg.in/yaml.v3"
@@ -59,7 +58,6 @@ func UnCDK(t cft.Template) error {
 	}
 
 	commonPrefix := getCommonResourcePrefix(t)
-	config.Debugf("commonPrefix is %s", commonPrefix)
 
 	// Store the resource logical id node each time we see a repeated name
 	// Start without a number, for example "Bucket"
@@ -84,7 +82,6 @@ func UnCDK(t cft.Template) error {
 			// We've seen this one before
 			nameNodes = append(nameNodes, resources.Content[i])
 			allNames[newName] = nameNodes
-			config.Debugf("For %s (%s), nameNodes is now %v", logicalId, newName, nameNodes)
 			for nodeIdx, node := range nameNodes {
 				sequential := fmt.Sprintf("%s%d", newName, nodeIdx)
 				priorValue := node.Value
@@ -161,15 +158,12 @@ func joinToSub(t cft.Template) {
 		yamlNode := n.GetYamlNode()
 		if yamlNode.Kind == yaml.MappingNode {
 			if len(yamlNode.Content) == 2 && yamlNode.Content[0].Value == "Fn::Join" {
-				config.Debugf("Found a Join: %s", node.ToSJson(yamlNode))
 				seq := yamlNode.Content[1]
 				if seq.Kind == yaml.SequenceNode {
 					yamlNode.Content[0].Value = "Fn::Sub"
 					yamlNode.Content[1].Value = joinSeqToString(seq)
 					yamlNode.Content[1].Kind = yaml.ScalarNode
 					yamlNode.Content[1].Content = make([]*yaml.Node, 0)
-
-					config.Debugf("after: %s", node.ToSJson(yamlNode))
 				}
 			}
 		}
@@ -184,7 +178,6 @@ func replaceNames(t cft.Template, oldName, newName string) {
 		yamlNode := n.GetYamlNode()
 		if yamlNode.Kind == yaml.ScalarNode {
 			if yamlNode.Value == oldName {
-				config.Debugf("replaceNames %s %s", oldName, newName)
 				yamlNode.Value = newName
 			}
 		}
@@ -204,7 +197,6 @@ func getCommonResourcePrefix(t cft.Template) string {
 		logicalId := resources.Content[i].Value
 		logicalIds = append(logicalIds, logicalId)
 	}
-	config.Debugf("logicalIds: %v", logicalIds)
 	return getCommonPrefix(logicalIds)
 }
 
@@ -237,7 +229,6 @@ func getCommonPrefix(logicalIds []string) string {
 		}
 	}
 
-	config.Debugf("getCommonPrefix candidate is %s", retval)
 	common := true
 	for _, id := range logicalIds {
 		if !strings.HasPrefix(id, retval) {

--- a/cft/format/uncdk_test.go
+++ b/cft/format/uncdk_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/aws-cloudformation/rain/cft/diff"
 	"github.com/aws-cloudformation/rain/cft/parse"
 	"github.com/aws-cloudformation/rain/internal/config"
-	"github.com/aws-cloudformation/rain/internal/node"
 )
 
 func TestRemoveEmptySections(t *testing.T) {
@@ -38,9 +37,6 @@ func TestUnCDK(t *testing.T) {
 		t.Fatalf("could not parse %s: %v", path, err)
 	}
 
-	config.Debug = true
-	config.Debugf("%s", node.ToSJson(template.Node))
-
 	expectPath := "../../test/templates/uncdk-expect.yaml"
 	expectedTemplate, err := parse.File(expectPath)
 	if err != nil {
@@ -57,4 +53,64 @@ func TestUnCDK(t *testing.T) {
 		t.Errorf("Output does not match expected: %v", d.Format(true))
 	}
 
+}
+
+func TestGetCommonPrefix(t *testing.T) {
+	testCases := []struct {
+		name           string
+		logicalIds     []string
+		expectedPrefix string
+	}{
+		{
+			name:           "Empty slice",
+			logicalIds:     []string{},
+			expectedPrefix: "",
+		},
+		{
+			name:           "Single element",
+			logicalIds:     []string{"Busket"},
+			expectedPrefix: "",
+		},
+		{
+			name:           "Common prefix",
+			logicalIds:     []string{"BucketA", "BucketB", "BucketC"},
+			expectedPrefix: "Bucket",
+		},
+		{
+			name:           "No common prefix",
+			logicalIds:     []string{"BucketA", "QueueB", "TableC"},
+			expectedPrefix: "",
+		},
+		{
+			name:           "Mixed case",
+			logicalIds:     []string{"BucketA", "bucketB", "BucketC"},
+			expectedPrefix: "",
+		},
+		{
+			name: "TryConvertCdk",
+			logicalIds: []string{
+				"TryConvertCdkQueueA6B3948A",
+				"TryConvertCdkQueueA6B3948B",
+				"TryConvertCdkQueueA6B3948C",
+				"TryConvertCdkQueuePolicy8C365983",
+				"TryConvertCdkQueueTryConvertCdkStackTryConvertCdkTopic4C9C531F7A91899A",
+				"TryConvertCdkTopic2CABFDF4",
+				"TryConvertCdkACustomResource",
+				"TryConvertCdkAnotherCustomResource",
+				"TryConvertCdkAnotherCustomResource2",
+			},
+			expectedPrefix: "TryConvertCdk",
+		},
+	}
+
+	config.Debug = true
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			prefix := getCommonPrefix(tc.logicalIds)
+			if prefix != tc.expectedPrefix {
+				t.Errorf("Expected prefix '%s', got '%s'", tc.expectedPrefix, prefix)
+			}
+		})
+	}
 }

--- a/cft/format/uncdk_test.go
+++ b/cft/format/uncdk_test.go
@@ -1,0 +1,60 @@
+package format
+
+import (
+	"testing"
+
+	"github.com/aws-cloudformation/rain/cft"
+	"github.com/aws-cloudformation/rain/cft/diff"
+	"github.com/aws-cloudformation/rain/cft/parse"
+	"github.com/aws-cloudformation/rain/internal/config"
+	"github.com/aws-cloudformation/rain/internal/node"
+)
+
+func TestRemoveEmptySections(t *testing.T) {
+	src := `
+Parameters: {}
+Resources:
+  Bucket:
+    Type: AWS::S3::Bucket
+`
+	template, err := parse.String(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	template.RemoveEmptySections()
+
+	params, err := template.GetSection(cft.Parameters)
+	if err == nil && params != nil {
+		t.Fatal("expected Parameters section to be removed")
+	}
+
+}
+
+func TestUnCDK(t *testing.T) {
+
+	path := "../../test/templates/uncdk.yaml"
+	template, err := parse.File(path)
+	if err != nil {
+		t.Fatalf("could not parse %s: %v", path, err)
+	}
+
+	config.Debug = true
+	config.Debugf("%s", node.ToSJson(template.Node))
+
+	expectPath := "../../test/templates/uncdk-expect.yaml"
+	expectedTemplate, err := parse.File(expectPath)
+	if err != nil {
+		t.Fatalf("could not parse %s: %v", expectPath, err)
+	}
+
+	err = UnCDK(template)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	d := diff.New(template, expectedTemplate)
+	if d.Mode() != "=" {
+		t.Errorf("Output does not match expected: %v", d.Format(true))
+	}
+
+}

--- a/internal/cmd/fmt/fmt.go
+++ b/internal/cmd/fmt/fmt.go
@@ -24,6 +24,7 @@ var verifyFlag bool
 var writeFlag bool
 var unsortedFlag bool
 var dataModel bool
+var uncdk bool
 
 // pklPackageAlias is the package name to use in module imports
 var pklPackageAlias string = "@cfn"
@@ -48,6 +49,16 @@ func formatString(input string, res *result) {
 	}
 
 	config.Debugf("%s", node.ToSJson(source.Node))
+
+	if uncdk {
+		// Remove CDK Metadata
+		// Simplify logical IDs
+		err := format.UnCDK(source)
+		if err != nil {
+			res.err = ui.Errorf(err, "uncdk failed")
+			return
+		}
+	}
 
 	if dataModel {
 		res.output = node.ToJson(source.Node)
@@ -202,4 +213,5 @@ func init() {
 	Cmd.Flags().BoolVar(&dataModel, "datamodel", false, "Output the go yaml data model")
 	Cmd.Flags().StringVar(&pklPackageAlias, "pkl-package", "@cfn", "An alias or full package URI for the Pkl package for generated Pkl files")
 	Cmd.Flags().StringVar(&format.NodeStyle, "node-style", "", format.NodeStyleDocs)
+	Cmd.Flags().BoolVar(&uncdk, "uncdk", false, "Remove CDK Metadata and simplify logical ids")
 }

--- a/test/templates/notcontains.yaml
+++ b/test/templates/notcontains.yaml
@@ -1,0 +1,12 @@
+Rules:
+  CheckBootstrapVersion:
+    Assertions:
+      - Assert: !Not
+          - !Contains
+            - - '1'
+              - '2'
+              - '3'
+              - '4'
+              - '5'
+            - !Ref BootstrapVersion
+

--- a/test/templates/uncdk-expect.yaml
+++ b/test/templates/uncdk-expect.yaml
@@ -13,6 +13,13 @@ Resources:
     Properties:
       VisibilityTimeout: 300
 
+  Queue2:
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Type: AWS::SQS::Queue
+    Properties:
+      VisibilityTimeout: 300
+
   QueuePolicy:
     Type: AWS::SQS::QueuePolicy
     Metadata:
@@ -44,3 +51,22 @@ Resources:
 
   Topic:
     Type: AWS::SNS::Topic
+
+  CustomThing:
+    Type: Custom::CustomThing
+    Properties:
+      ServiceToken: foo
+
+  AnotherCustomThing0:
+    Type: Custom::AnotherCustomThing
+    Properties:
+      ServiceToken: foo
+
+  AnotherCustomThing1:
+    Type: Custom::AnotherCustomThing
+    Properties:
+      ServiceToken: foo
+
+Outputs:
+  TryConvertCdkQueueA6B3948CName:
+    Value: !Ref Queue2

--- a/test/templates/uncdk-expect.yaml
+++ b/test/templates/uncdk-expect.yaml
@@ -1,0 +1,46 @@
+Resources:
+  Queue0:
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Type: AWS::SQS::Queue
+    Properties:
+      VisibilityTimeout: 300
+
+  Queue1:
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Type: AWS::SQS::Queue
+    Properties:
+      VisibilityTimeout: 300
+
+  QueuePolicy:
+    Type: AWS::SQS::QueuePolicy
+    Metadata:
+      Comment: A comment
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action: sqs:SendMessage
+            Condition:
+              ArnEquals:
+                aws:SourceArn: !Ref Topic
+            Effect: Allow
+            Principal:
+              Service: sns.amazonaws.com
+            Resource: !GetAtt Queue0.Arn
+        Version: "2012-10-17"
+      Queues:
+        - !Ref Queue0
+        - !Ref Queue1
+
+  Subscription:
+    Type: AWS::SNS::Subscription
+    DependsOn:
+      - QueuePolicy
+    Properties:
+      Endpoint: !GetAtt Queue0.Arn
+      Protocol: sqs
+      TopicArn: !Ref Topic
+
+  Topic:
+    Type: AWS::SNS::Topic

--- a/test/templates/uncdk-expect.yaml
+++ b/test/templates/uncdk-expect.yaml
@@ -40,7 +40,7 @@ Resources:
         - !Ref Queue0
         - !Ref Queue1
 
-  Subscription:
+  QueueStackTopic:
     Type: AWS::SNS::Subscription
     DependsOn:
       - QueuePolicy
@@ -52,17 +52,17 @@ Resources:
   Topic:
     Type: AWS::SNS::Topic
 
-  CustomThing:
+  ACustomResource:
     Type: Custom::CustomThing
     Properties:
       ServiceToken: foo
 
-  AnotherCustomThing0:
+  AnotherCustomResource:
     Type: Custom::AnotherCustomThing
     Properties:
       ServiceToken: foo
 
-  AnotherCustomThing1:
+  AnotherCustomResource2:
     Type: Custom::AnotherCustomThing
     Properties:
       ServiceToken: foo

--- a/test/templates/uncdk-expect.yaml
+++ b/test/templates/uncdk-expect.yaml
@@ -66,6 +66,8 @@ Resources:
     Type: Custom::AnotherCustomThing
     Properties:
       ServiceToken: foo
+      FixThisJoin:
+        Fn::Sub: arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:${Foo.Bar}
 
 Outputs:
   TryConvertCdkQueueA6B3948CName:

--- a/test/templates/uncdk.yaml
+++ b/test/templates/uncdk.yaml
@@ -179,17 +179,17 @@ Resources:
     Metadata:
       aws:cdk:path: TryConvertCdkStack/TryConvertCdkTopic/Resource
 
-  ACustomResource:
+  TryConvertCdkACustomResourceABCDEFGH:
     Type: Custom::CustomThing
     Properties:
       ServiceToken: foo
 
-  AnotherCustomResource:
+  TryConvertCdkAnotherCustomResourceABCDEFGI:
     Type: Custom::AnotherCustomThing
     Properties:
       ServiceToken: foo
 
-  AnotherCustomResource2:
+  TryConvertCdkAnotherCustomResource2ABCDEFGJ:
     Type: Custom::AnotherCustomThing
     Properties:
       ServiceToken: foo

--- a/test/templates/uncdk.yaml
+++ b/test/templates/uncdk.yaml
@@ -193,6 +193,19 @@ Resources:
     Type: Custom::AnotherCustomThing
     Properties:
       ServiceToken: foo
+      FixThisJoin: 
+        Fn::Join:
+          - ""
+          - - "arn:"
+            - Ref: AWS::Partition
+            - ":logs:"
+            - Ref: AWS::Region
+            - ":"
+            - Ref: AWS::AccountId
+            - ":"
+            - Fn::GetAtt:
+              - "Foo"
+              - "Bar"
 
   CDKMetadata:
     Type: AWS::CDK::Metadata

--- a/test/templates/uncdk.yaml
+++ b/test/templates/uncdk.yaml
@@ -133,6 +133,14 @@ Resources:
       aws:cdk:path: TryConvertCdkStack/TryConvertCdkQueue/Resource
     Properties:
       VisibilityTimeout: 300
+  TryConvertCdkQueueA6B3948C:
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Type: AWS::SQS::Queue
+    Metadata:
+      aws:cdk:path: TryConvertCdkStack/TryConvertCdkQueue/Resource
+    Properties:
+      VisibilityTimeout: 300
 
   TryConvertCdkQueuePolicy8C365983:
     Type: AWS::SQS::QueuePolicy
@@ -171,6 +179,21 @@ Resources:
     Metadata:
       aws:cdk:path: TryConvertCdkStack/TryConvertCdkTopic/Resource
 
+  ACustomResource:
+    Type: Custom::CustomThing
+    Properties:
+      ServiceToken: foo
+
+  AnotherCustomResource:
+    Type: Custom::AnotherCustomThing
+    Properties:
+      ServiceToken: foo
+
+  AnotherCustomResource2:
+    Type: Custom::AnotherCustomThing
+    Properties:
+      ServiceToken: foo
+
   CDKMetadata:
     Type: AWS::CDK::Metadata
     Metadata:
@@ -178,3 +201,7 @@ Resources:
     Properties:
       Analytics: v2:deflate64:H4sIAAAAAAAA/1WNQQqDMBREz+I+/hop9ABeoNXuS0xS+GoT9SeVEnL3kgQK3cy8GQamBX45A6/EQbVUc73gCGFwQs5MHPQItBGEm9des+5pCmS92gXl51eWGBkZgjD4keSOq0Nr0uIv3+2KMrUZYkzYa7J+l/mjs0ZhWkZmrNIw0endNsBbaKqJEOvdG4cvDX3xL90E7lHCAAAA
     Condition: CDKMetadataAvailable
+
+Outputs:
+  TryConvertCdkQueueA6B3948CName:
+    Value: !Ref TryConvertCdkQueueA6B3948C

--- a/test/templates/uncdk.yaml
+++ b/test/templates/uncdk.yaml
@@ -1,0 +1,180 @@
+Parameters:
+  BootstrapVersion:
+    Description: Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /cdk-bootstrap/hnb659fds/version
+
+Rules:
+  CheckBootstrapVersion:
+    Assertions:
+      - Assert: !Not
+          - Fn::Contains:
+              - - "1"
+                - "2"
+                - "3"
+                - "4"
+                - "5"
+              - !Ref BootstrapVersion
+        AssertDescription: CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.
+
+Conditions:
+  CDKMetadataAvailable: !Or
+    - !Or
+      - !Equals
+        - !Ref AWS::Region
+        - af-south-1
+      - !Equals
+        - !Ref AWS::Region
+        - ap-east-1
+      - !Equals
+        - !Ref AWS::Region
+        - ap-northeast-1
+      - !Equals
+        - !Ref AWS::Region
+        - ap-northeast-2
+      - !Equals
+        - !Ref AWS::Region
+        - ap-northeast-3
+      - !Equals
+        - !Ref AWS::Region
+        - ap-south-1
+      - !Equals
+        - !Ref AWS::Region
+        - ap-south-2
+      - !Equals
+        - !Ref AWS::Region
+        - ap-southeast-1
+      - !Equals
+        - !Ref AWS::Region
+        - ap-southeast-2
+      - !Equals
+        - !Ref AWS::Region
+        - ap-southeast-3
+    - !Or
+      - !Equals
+        - !Ref AWS::Region
+        - ap-southeast-4
+      - !Equals
+        - !Ref AWS::Region
+        - ca-central-1
+      - !Equals
+        - !Ref AWS::Region
+        - ca-west-1
+      - !Equals
+        - !Ref AWS::Region
+        - cn-north-1
+      - !Equals
+        - !Ref AWS::Region
+        - cn-northwest-1
+      - !Equals
+        - !Ref AWS::Region
+        - eu-central-1
+      - !Equals
+        - !Ref AWS::Region
+        - eu-central-2
+      - !Equals
+        - !Ref AWS::Region
+        - eu-north-1
+      - !Equals
+        - !Ref AWS::Region
+        - eu-south-1
+      - !Equals
+        - !Ref AWS::Region
+        - eu-south-2
+    - !Or
+      - !Equals
+        - !Ref AWS::Region
+        - eu-west-1
+      - !Equals
+        - !Ref AWS::Region
+        - eu-west-2
+      - !Equals
+        - !Ref AWS::Region
+        - eu-west-3
+      - !Equals
+        - !Ref AWS::Region
+        - il-central-1
+      - !Equals
+        - !Ref AWS::Region
+        - me-central-1
+      - !Equals
+        - !Ref AWS::Region
+        - me-south-1
+      - !Equals
+        - !Ref AWS::Region
+        - sa-east-1
+      - !Equals
+        - !Ref AWS::Region
+        - us-east-1
+      - !Equals
+        - !Ref AWS::Region
+        - us-east-2
+      - !Equals
+        - !Ref AWS::Region
+        - us-west-1
+    - !Equals
+      - !Ref AWS::Region
+      - us-west-2
+
+Resources:
+  TryConvertCdkQueueA6B3948A:
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Type: AWS::SQS::Queue
+    Metadata:
+      aws:cdk:path: TryConvertCdkStack/TryConvertCdkQueue/Resource
+    Properties:
+      VisibilityTimeout: 300
+  TryConvertCdkQueueA6B3948B:
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Type: AWS::SQS::Queue
+    Metadata:
+      aws:cdk:path: TryConvertCdkStack/TryConvertCdkQueue/Resource
+    Properties:
+      VisibilityTimeout: 300
+
+  TryConvertCdkQueuePolicy8C365983:
+    Type: AWS::SQS::QueuePolicy
+    Metadata:
+      aws:cdk:path: TryConvertCdkStack/TryConvertCdkQueue/Policy/Resource
+      Comment: A comment
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action: sqs:SendMessage
+            Condition:
+              ArnEquals:
+                aws:SourceArn: !Ref TryConvertCdkTopic2CABFDF4
+            Effect: Allow
+            Principal:
+              Service: sns.amazonaws.com
+            Resource: !GetAtt TryConvertCdkQueueA6B3948A.Arn
+        Version: "2012-10-17"
+      Queues:
+        - !Ref TryConvertCdkQueueA6B3948A
+        - !Ref TryConvertCdkQueueA6B3948B
+
+  TryConvertCdkQueueTryConvertCdkStackTryConvertCdkTopic4C9C531F7A91899A:
+    Type: AWS::SNS::Subscription
+    DependsOn:
+      - TryConvertCdkQueuePolicy8C365983
+    Metadata:
+      aws:cdk:path: TryConvertCdkStack/TryConvertCdkQueue/TryConvertCdkStackTryConvertCdkTopic4C9C531F/Resource
+    Properties:
+      Endpoint: !GetAtt TryConvertCdkQueueA6B3948A.Arn
+      Protocol: sqs
+      TopicArn: !Ref TryConvertCdkTopic2CABFDF4
+
+  TryConvertCdkTopic2CABFDF4:
+    Type: AWS::SNS::Topic
+    Metadata:
+      aws:cdk:path: TryConvertCdkStack/TryConvertCdkTopic/Resource
+
+  CDKMetadata:
+    Type: AWS::CDK::Metadata
+    Metadata:
+      aws:cdk:path: TryConvertCdkStack/CDKMetadata/Default
+    Properties:
+      Analytics: v2:deflate64:H4sIAAAAAAAA/1WNQQqDMBREz+I+/hop9ABeoNXuS0xS+GoT9SeVEnL3kgQK3cy8GQamBX45A6/EQbVUc73gCGFwQs5MHPQItBGEm9des+5pCmS92gXl51eWGBkZgjD4keSOq0Nr0uIv3+2KMrUZYkzYa7J+l/mjs0ZhWkZmrNIw0endNsBbaKqJEOvdG4cvDX3xL90E7lHCAAAA
+    Condition: CDKMetadataAvailable


### PR DESCRIPTION
`rain fmt --uncdk` removes CDK Metadata and simplifies logical IDs from templates that were generated with `cdk synth`. This can be useful for pipelines where CDK is used strictly as a code generator and the templates are deployed separately, or if you use CDK as a starting point for declarative YAML CloudFormation development. 

This command only looks at a single template. The `rain merge` command can be used to stitch together separate templates from CDK output.