### PR TITLE
Adds optional Extension property to set extension on uploaded artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,28 +269,6 @@ Resources:
         S3Key: 1b4844dacc843f09941c11c94f80981d3be8ae7578952c71e875ef7add37b1a7
 ```
 
-Sometimes you require that objects uploaded to S3 have a specific extension, use the `Extension` property to ensure the artifact in S3 ends .<Extension>.
-
-```yaml
-Resources:
-  Test:
-    Type: A::B::C
-    Properties:
-      TheS3URI: !Rain::S3 
-        Path: test
-        Extension: sh
-```
-
-The packaged template:
-
-```yaml
-Resources:
-  Test:
-    Type: A::B::C
-    Properties:
-      TheS3URI: s3://rain-artifacts-012345678912-us-east-1/a84b588aa54068ed4b027b6e06e5e0bb283f83cf0d5a6720002d36af2225dfc3.sh
-```
-
 #### Metadata commands
 
 You can add a metadata section to an `AWS::S3::Bucket` resource to take additional actions during deployment, such as running pre and post build scripts, uploading content to the bucket after stack deployment completes, and emptying the contents of the bucket when the stack is deleted.

--- a/README.md
+++ b/README.md
@@ -269,6 +269,28 @@ Resources:
         S3Key: 1b4844dacc843f09941c11c94f80981d3be8ae7578952c71e875ef7add37b1a7
 ```
 
+Sometimes you require uploaded objects to have a specific extension
+
+```yaml
+Resources:
+  Test:
+    Type: A::B::C
+    Properties:
+      TheS3URI: !Rain::S3 
+        Path: test
+        Extension: sh
+```
+
+The packaged template:
+
+```yaml
+Resources:
+  Test:
+    Type: A::B::C
+    Properties:
+      TheS3URI: s3://rain-artifacts-012345678912-us-east-1/a84b588aa54068ed4b027b6e06e5e0bb283f83cf0d5a6720002d36af2225dfc3.sh
+```
+
 #### Metadata commands
 
 You can add a metadata section to an `AWS::S3::Bucket` resource to take additional actions during deployment, such as running pre and post build scripts, uploading content to the bucket after stack deployment completes, and emptying the contents of the bucket when the stack is deleted.

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Resources:
         S3Key: 1b4844dacc843f09941c11c94f80981d3be8ae7578952c71e875ef7add37b1a7
 ```
 
-Sometimes you require uploaded objects to have a specific extension
+Sometimes you require that objects uploaded to S3 have a specific extension, use the `Extension` property to ensure the artifact in S3 ends .<Extension>.
 
 ```yaml
 Resources:

--- a/cft/pkg/directives.go
+++ b/cft/pkg/directives.go
@@ -34,6 +34,7 @@ type s3Options struct {
 	Zip            bool     `yaml:"Zip"`
 	Format         s3Format `yaml:"Format"`
 	Run            string   `yaml:"Run"`
+	Extension      string   `yaml:"Extension"`
 }
 
 type directiveContext struct {
@@ -158,7 +159,7 @@ func handleS3(root string, options s3Options) (*yaml.Node, error) {
 		}
 	}
 
-	s, err := upload(root, options.Path, options.Zip)
+	s, err := upload(root, options.Path, options.Zip, options.Extension)
 	if err != nil {
 		return nil, err
 	}

--- a/cft/pkg/tmpl/s3-extension-template.yaml
+++ b/cft/pkg/tmpl/s3-extension-template.yaml
@@ -1,0 +1,7 @@
+Resources:
+  Test:
+    Type: A::B::C
+    Properties:
+      TheS3URI: !Rain::S3
+        Path: s3.txt
+        Extension: txt

--- a/cft/pkg/util.go
+++ b/cft/pkg/util.go
@@ -15,6 +15,7 @@
 //	`BucketProperty`: Name of returned property that will contain the bucket name
 //	`KeyProperty`: Name of returned property that will contain the object key
 //	`VersionProperty`: (optional) Name of returned property that will contain the object version
+//	`Extension`: (optional) Extension appended to the end of the Object Key in S3
 package pkg
 
 import (
@@ -111,7 +112,7 @@ func zipPath(root string) (string, error) {
 
 // Upload a file or directory to S3.
 // If path is a directory, it will be zipped first.
-func upload(root, path string, force bool) (*s3Path, error) {
+func upload(root, path string, force bool, extension string) (*s3Path, error) {
 	if !filepath.IsAbs(path) {
 		path = filepath.Join(root, path)
 		if abs, err := filepath.Abs(path); err == nil {
@@ -152,7 +153,7 @@ func upload(root, path string, force bool) (*s3Path, error) {
 	}
 
 	bucket := s3.RainBucket(false)
-	key, err := s3.Upload(bucket, content)
+	key, err := s3.Upload(bucket, content, extension)
 
 	uploads[artifactName] = &s3Path{
 		bucket: bucket,

--- a/docs/README.tmpl
+++ b/docs/README.tmpl
@@ -241,6 +241,28 @@ Resources:
         S3Key: 1b4844dacc843f09941c11c94f80981d3be8ae7578952c71e875ef7add37b1a7
 ```
 
+Sometimes you require that objects uploaded to S3 have a specific extension, use the `Extension` property to ensure the artifact in S3 ends .<Extension>.
+
+```yaml
+Resources:
+  Test:
+    Type: A::B::C
+    Properties:
+      TheS3URI: !Rain::S3
+        Path: test
+        Extension: sh
+```
+
+The packaged template:
+
+```yaml
+Resources:
+  Test:
+    Type: A::B::C
+    Properties:
+      TheS3URI: s3://rain-artifacts-012345678912-us-east-1/a84b588aa54068ed4b027b6e06e5e0bb283f83cf0d5a6720002d36af2225dfc3.sh
+```
+
 #### Metadata commands
 
 You can add a metadata section to an `AWS::S3::Bucket` resource to take additional actions during deployment, such as running pre and post build scripts, uploading content to the bucket after stack deployment completes, and emptying the contents of the bucket when the stack is deleted.

--- a/docs/rain_pkg.md
+++ b/docs/rain_pkg.md
@@ -29,6 +29,7 @@ You may use the following, rain-specific directives in templates packaged with "
     Format: Uri|Http           Specify which format rain pkg should return the S3 location as.
                                Do not specify this property if you supply BucketProperty and KeyProperty.
                                The default Format is "Uri".
+    Extension: <ext>           If specified, Appends .<ext> to the artifact object in S3.
 
   !Rain::Module <url>          Supply a URL to a rain module, which is similar to a CloudFormation module, 
                                but allows for type inheritance. One of the resources in the module yaml file 

--- a/internal/aws/cfn/cfn.go
+++ b/internal/aws/cfn/cfn.go
@@ -74,7 +74,7 @@ func checkTemplate(template cft.Template) (string, error) {
 
 		bucket := s3.RainBucket(false)
 
-		key, err := s3.Upload(bucket, []byte(templateBody))
+		key, err := s3.Upload(bucket, []byte(templateBody), "")
 		region := aws.Config().Region
 		if strings.HasPrefix(region, "cn-") {
 			return fmt.Sprintf("https://%s.s3.%s.amazonaws.com.cn/%s", bucket, region, key), err

--- a/internal/aws/s3/s3.go
+++ b/internal/aws/s3/s3.go
@@ -173,7 +173,7 @@ func CreateBucket(bucketName string) error {
 }
 
 // Upload uploads an artifact to the bucket with a unique name
-func Upload(bucketName string, content []byte) (string, error) {
+func Upload(bucketName string, content []byte, extension string) (string, error) {
 	isBucketExists, errBucketExists := BucketExists(bucketName)
 
 	if errBucketExists != nil {
@@ -185,6 +185,9 @@ func Upload(bucketName string, content []byte) (string, error) {
 	}
 
 	key := filepath.Join(BucketKeyPrefix, fmt.Sprintf("%x", sha256.Sum256(content)))
+	if extension != "" {
+		key = fmt.Sprintf("%s.%s", key, extension)
+	}
 
 	accountId, err := getAccountId()
 	if err != nil {

--- a/scripts/integ.sh
+++ b/scripts/integ.sh
@@ -47,7 +47,8 @@ set -eoux pipefail
 ./rain --profile rain pkg cft/pkg/tmpl/include-template.yaml
 ./rain --profile rain pkg cft/pkg/tmpl/s3-template.yaml
 ./rain --profile rain pkg cft/pkg/tmpl/s3http-template.yaml
-./rain --profile rain pkg cft/pkg/tmpl/s3-extension-template.yaml
+# Given a Template with an Extension value of txt, When Packaged, Then the S3 URI ends '.txt'
+./rain --profile rain pkg cft/pkg/tmpl/s3-extension-template.yaml | yq --exit-status '.Resources.Test.Properties.TheS3URI | test("\.txt$")'
 
 # Make sure merge works
 ./rain merge test/templates/merge-out-1.yaml test/templates/merge-out-2.yaml

--- a/scripts/integ.sh
+++ b/scripts/integ.sh
@@ -47,6 +47,7 @@ set -eoux pipefail
 ./rain --profile rain pkg cft/pkg/tmpl/include-template.yaml
 ./rain --profile rain pkg cft/pkg/tmpl/s3-template.yaml
 ./rain --profile rain pkg cft/pkg/tmpl/s3http-template.yaml
+./rain --profile rain pkg cft/pkg/tmpl/s3-extension-template.yaml
 
 # Make sure merge works
 ./rain merge test/templates/merge-out-1.yaml test/templates/merge-out-2.yaml


### PR DESCRIPTION
*Issue #, if available:* #643 

*Description of changes:*
Some AWS services require that the objects they access in S3 have a particular extension.

This meant rain was previously incompatbile with that requirement.

this change allows a user to specify the extension to append to the uploaded artifact in S3.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
