### PR TITLE
Fix #653: incorrectly strips quotes from string values that resemble YAML booleans

### DIFF
--- a/cft/format/transform.go
+++ b/cft/format/transform.go
@@ -120,11 +120,25 @@ func formatNode(n *yaml.Node) *yaml.Node {
 			n.Style = yaml.DoubleQuotedStyle
 		}
 	case "":
-		// Default style for consistent formatting
-		n.Style = 0
+		// Default style for consistent formatting:
+		// Force double quotes on ambiguous scalar strings.
+		if n.Kind == yaml.ScalarNode && n.Tag == "!!str" && isAmbiguousScalar(n.Value) {
+			n.Style = yaml.DoubleQuotedStyle
+		} else {
+			n.Style = 0
+		}
 	default:
 		panic("invalid --node-style: " + NodeStyle)
 	}
 
 	return n
+}
+
+func isAmbiguousScalar(val string) bool {
+	switch strings.ToLower(val) {
+	case "y", "yes", "n", "no", "true", "false", "on", "off":
+		return true
+	default:
+		return false
+	}
 }


### PR DESCRIPTION
*Issue #, if available:*
 #653

*Description of changes:*
Ensure ambiguous YAML scalars (`ON`, `OFF`, `YES`, `NO`, `TRUE`, `FALSE`) remain quoted to prevent unintended type conversion in CloudFormation templates. Includes tests to verify correct handling in `Parameters` and `Properties`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
