### PR TITLE
Update .pre-commit-hooks.yaml to use rain instead of cfn-format

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,15 @@
-- id: cfn-format
-  name: Format CloudFormation templates
-  entry: cfn-format -w
+- id: rain-format
+  name: rain format
+  description: Format AWS CloudFormation templates
+  entry: rain
   language: golang
-  files: \.template$
-  description: Format CloudFormation templates
+  files: \.(yml|yaml|json)$
+  args: ["fmt", "-w"]
+
+- id: rain-verify
+  name: rain verify
+  description: Verify AWS CloudFormation templates formatting without modifying files
+  entry: rain
+  language: golang
+  files: \.(yml|yaml|json)$
+  args: ["fmt", "-v"]


### PR DESCRIPTION
**Issue #, if available:**

#671

**Description of changes:**

This PR updates the `.pre-commit-hooks.yaml` file to replace the outdated `cfn-format` hook with two new hooks using the `rain` CLI tool:

- `rain-format`: Formats AWS CloudFormation templates using `rain fmt -w`
- `rain-verify`: Verifies formatting without modifying files using `rain fmt -v`

These hooks support both YAML and JSON CloudFormation templates (`.yaml`, `.yml`, and `.json` file extensions).

Using `rain` in pre-commit hooks provides a modern and maintained way to enforce consistent formatting in CloudFormation templates. It also enables integration with the [pre-commit framework](https://pre-commit.com/) for both local development and CI pipelines.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
