### PR TITLE
Add example for specifying tags/params via file

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,36 @@ Rain is licensed under the Apache 2.0 License.
 
 ## Example Usage
 
+### Specifying Parameter and Tag Values via File
+
+The config flag can be used to programmatically set tags and parameters. The
+format is similar to the "Template configuration file" for AWS CodePipeline
+just without the 'StackPolicy' key. The file can be in YAML or JSON format.
+
+JSON:
+```json
+{
+  "Parameters" : {
+    "NameOfTemplateParameter1" : "ValueOfParameter1",
+    "NameOfTemplateParameter2" : "ValueOfParameter2"
+  },
+  "Tags" : {
+    "TagKey1" : "TagValue1",
+    "TagKey2" : "TagValue2"
+  }
+}
+```
+
+YAML:
+```yaml
+Parameters:
+  NameOfTemplateParameter1: ValueOfParameter1
+  NameOfTemplateParameter2: ValueOfParameter2
+Tags:
+  TagKey1: TagValue1
+  TagKey2: TagValue2
+```
+
 ### Packaging
 
 The `rain pkg` command can be used as a replacement for the `aws cloudformation


### PR DESCRIPTION
*Description of changes:*

This PR adds an example of the tag and parameter format, taken from [internal/cmd/deploy/deploy_test.go](https://github.com/aws-cloudformation/rain/pull/78/files#diff-8c53c47e7691e3d19cfda07de30cd3b5ae1c2623e8a876fd8bd9e4e18611f05f) with the ellipses removed due to syntax.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
