### PR TITLE
Collect all unknown parameters before reporting

### DIFF
--- a/internal/dc/dc.go
+++ b/internal/dc/dc.go
@@ -50,13 +50,17 @@ func GetParameters(
 
 	if params, ok := template.Map()["Parameters"]; ok {
 		// Check we don't have any unknown params
+		unknownParams := make([]string, 0)
 		for k := range combinedParameters {
 			if _, ok := params.(map[string]interface{})[k]; !ok {
-				if ignoreUnknownParams {
-					fmt.Println(console.Yellow(fmt.Sprintf("unknown parameter: %s", k)))
-				} else {
-					panic(fmt.Errorf("unknown parameter: %s\nif you want to proceed as is, add the --ignore-unknown-params flag", k))
-				}
+				unknownParams = append(unknownParams, k)
+			}
+		}
+		if len(unknownParams) > 0 {
+			if ignoreUnknownParams {
+				fmt.Println(console.Yellow(fmt.Sprintf("unknown parameters: %v", unknownParams)))
+			} else {
+				panic(fmt.Errorf("unknown parameters: %v\nif you want to proceed as is, add the --ignore-unknown-params flag", unknownParams))
 			}
 		}
 


### PR DESCRIPTION
https://github.com/aws-cloudformation/rain/issues/776

Previously, unknown parameter validation would report or panic on the first unknown parameter found. This change collects all unknown parameters first and reports them together in a single message, making it easier to identify and fix multiple unknown parameters at once.
