### PR TITLE
Fix CRLF line endings causing extra blank lines between comments

### DIFF
--- a/cft/format/crlf_test.go
+++ b/cft/format/crlf_test.go
@@ -1,0 +1,49 @@
+package format_test
+
+import (
+	"testing"
+
+	"github.com/aws-cloudformation/rain/cft/format"
+	"github.com/aws-cloudformation/rain/cft/parse"
+)
+
+func TestCRLFComments(t *testing.T) {
+	// Issue #479: Windows CRLF line endings cause extra blank lines between comments
+	// Build input with CRLF line endings
+	input := "AWSTemplateFormatVersion: 2010-09-09\r\n" +
+		"\r\n" +
+		"# Comment line 1\r\n" +
+		"# Comment line 2\r\n" +
+		"# Comment line 3\r\n" +
+		"\r\n" +
+		"Description: Hello World\r\n"
+
+	// Same input with LF line endings for comparison
+	inputLF := "AWSTemplateFormatVersion: 2010-09-09\n" +
+		"\n" +
+		"# Comment line 1\n" +
+		"# Comment line 2\n" +
+		"# Comment line 3\n" +
+		"\n" +
+		"Description: Hello World\n"
+
+	tmplCRLF, err := parse.String(input)
+	if err != nil {
+		t.Fatalf("Failed to parse CRLF input: %v", err)
+	}
+
+	tmplLF, err := parse.String(inputLF)
+	if err != nil {
+		t.Fatalf("Failed to parse LF input: %v", err)
+	}
+
+	outputCRLF := format.String(tmplCRLF, format.Options{})
+	outputLF := format.String(tmplLF, format.Options{})
+
+	t.Logf("CRLF output:\n---\n%s\n---", outputCRLF)
+	t.Logf("LF output:\n---\n%s\n---", outputLF)
+
+	if outputCRLF != outputLF {
+		t.Errorf("CRLF and LF outputs differ.\nCRLF output:\n%s\nLF output:\n%s", outputCRLF, outputLF)
+	}
+}

--- a/cft/parse/parse.go
+++ b/cft/parse/parse.go
@@ -58,6 +58,7 @@ func Map(input map[string]interface{}) (*cft.Template, error) {
 
 // String returns a cft.Template parsed from a string
 func String(input string) (*cft.Template, error) {
+	input = strings.ReplaceAll(input, "\r", "")
 	var n yaml.Node
 	err := yaml.Unmarshal([]byte(input), &n)
 	if err != nil {


### PR DESCRIPTION
*Issue #, if available:* #479

*Description of changes:*

When a YAML template with Windows-style CRLF (`\r\n`) line endings is formatted with `rain fmt`, extra blank lines are inserted between consecutive comment lines. This is because `yaml.v3` preserves `\r` characters in node comment fields, and the formatting logic in `format.go` treats `\r`-only lines as non-empty content.

The fix strips `\r` characters from the input at the beginning of `parse.String()`, before passing it to `yaml.Unmarshal`. This normalizes line endings at the pipeline entry point, ensuring CRLF and LF inputs produce identical formatted output.

Design doc: https://gist.github.com/cv-dote/713ad53ab1b29672ae8c3910e496d40d