### PR TITLE
Upgrade golang stdlib from 1.26.0 to 1.26.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws-cloudformation/rain
 
-go 1.26.0
+go 1.26.2
 
 require (
 	//github.com/ake-persson/mapslice-json v0.0.0-20210720081907-22c8edf57807


### PR DESCRIPTION
*Description of changes:*
Updating GoLang stdlib from version 1.26.0 to 1.26.2 (the latest stable version as of april 10 2026)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
