### PR TITLE
docs: add deprecation notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,29 @@
 
 # Rain
 
+> [!WARNING]
+> ## ⚠️ This project is deprecated
+>
+> **Rain is no longer actively maintained and has been deprecated.** We are no
+> longer accepting feature requests, and issues and pull requests may not be
+> reviewed or merged. The repository will remain available in an archived,
+> read-only state so that existing users can continue to reference the source
+> and prior releases.
+>
+> Existing binaries and releases will continue to be available on the
+> [releases page](https://github.com/aws-cloudformation/rain/releases), but no
+> new releases, bug fixes, or security patches are planned.
+>
+> We recommend migrating to actively supported alternatives such as the
+> [AWS CLI](https://aws.amazon.com/cli/) for CloudFormation operations,
+> the [AWS CDK](https://aws.amazon.com/cdk/) for authoring reusable
+> infrastructure components such as modules,
+> [cfn-lint](https://github.com/aws-cloudformation/cfn-lint) for template
+> validation, and [cfn-guard](https://github.com/aws-cloudformation/cloudformation-guard)
+> for policy checks.
+>
+> Thank you to everyone who contributed to and used Rain over the years.
+
 * Documentation: <https://aws-cloudformation.github.io/rain/>
 
 > Rain is what happens when you have a lot of CloudFormation

--- a/docs/README.tmpl
+++ b/docs/README.tmpl
@@ -3,6 +3,29 @@
 
 # Rain
 
+> [!WARNING]
+> ## ⚠️ This project is deprecated
+>
+> **Rain is no longer actively maintained and has been deprecated.** We are no
+> longer accepting feature requests, and issues and pull requests may not be
+> reviewed or merged. The repository will remain available in an archived,
+> read-only state so that existing users can continue to reference the source
+> and prior releases.
+>
+> Existing binaries and releases will continue to be available on the
+> [releases page](https://github.com/aws-cloudformation/rain/releases), but no
+> new releases, bug fixes, or security patches are planned.
+>
+> We recommend migrating to actively supported alternatives such as the
+> [AWS CLI](https://aws.amazon.com/cli/) for CloudFormation operations,
+> the [AWS CDK](https://aws.amazon.com/cdk/) for authoring reusable
+> infrastructure components such as modules,
+> [cfn-lint](https://github.com/aws-cloudformation/cfn-lint) for template
+> validation, and [cfn-guard](https://github.com/aws-cloudformation/cloudformation-guard)
+> for policy checks.
+>
+> Thank you to everyone who contributed to and used Rain over the years.
+
 * Documentation: <https://aws-cloudformation.github.io/rain/>
 
 > Rain is what happens when you have a lot of CloudFormation


### PR DESCRIPTION
## Summary

Rain is no longer actively maintained and will be archived shortly after this change merges. This PR adds a prominent deprecation notice to the top of the README so users are informed before they invest in adopting the tool.

## Changes

- Add a `> [!WARNING]` deprecation callout at the top of `README.md`, covering:
  - Rain is deprecated / no longer actively maintained
  - Issues and PRs may not be reviewed or merged
  - Repo will move to an archived, read-only state
  - Existing releases remain available; no new releases or security patches
  - Recommended alternatives: AWS CLI, AWS CDK (for reusable components such as modules), cfn-lint, cfn-guard
- Mirror the same notice into `docs/README.tmpl`, since `README.md` is generated via `go generate` and an edit to `README.md` alone would be overwritten on the next regeneration.

## Notes

The repository is expected to be archived within a day or two of this merging.